### PR TITLE
Implement marker cache system

### DIFF
--- a/src/js/ol3-map-widget.js
+++ b/src/js/ol3-map-widget.js
@@ -311,11 +311,11 @@
             if (poi_info.selectable) {
                 let marker;
                 switch (geometry.getType()) {
-                case "polygon":
+                case "Polygon":
                     marker = new ol.geom.Point(geometry.getInteriorPoint());
                     geometry = new ol.geom.GeometryCollection([geometry, marker]);
                     break;
-                case "lineString":
+                case "LineString":
                     marker = new ol.geom.Point(geometry.getCoordinateAt(0.5));
                     geometry = new ol.geom.GeometryCollection([geometry, marker]);
                     break;

--- a/src/js/ol3-map-widget.js
+++ b/src/js/ol3-map-widget.js
@@ -151,6 +151,49 @@
         };
     };
 
+    var parse_marker_definition = function parse_marker_definition(icon, vector_style) {
+        if (icon == null) {
+            icon = {};
+        }
+
+        if (icon.hash != null && icon.hash in this.marker_cache) {
+            return this.marker_cache[icon.hash];
+        }
+
+        if (!Array.isArray(icon.anchor)) {
+            icon.anchor = [0.5, 0.5];
+        }
+
+        if (icon.opacity == null || typeof icon.opacity !== "number") {
+            icon.opacity = 1;
+        }
+
+        if (icon.scale == null || typeof icon.scale !== "number") {
+            icon.scale = 1;
+        }
+
+        if (icon.src != null) {
+            var image = new ol.style.Icon(/** @type {olx.style.IconOptions} */ ({
+                anchor: icon.anchor,
+                anchorXUnits: icon.anchorXUnits,
+                anchorYUnits: icon.anchorYUnits,
+                opacity: icon.opacity,
+                src: icon.src,
+                scale: icon.scale
+            }));
+        }
+        let marker_style = build_basic_style.call(this, {
+            image: image,
+            style: vector_style
+        });
+
+        if (icon.hash != null) {
+            this.marker_cache[icon.hash] = marker_style;
+        }
+
+        return marker_style;
+    };
+
     var send_visible_pois = function send_visible_pois() {
 
         if (this.visiblePoisTimeout != null) {
@@ -196,6 +239,7 @@
         }
 
         this.vector_source = new ol.source.Vector({});
+        this.marker_cache = {};
         this.vector_layer = new ol.layer.Vector({source: this.vector_source, style: DEFAULT_MARKER});
         this.map = new ol.Map({
             target: document.getElementById('map'),
@@ -246,60 +290,69 @@
 
         // send poi updates on changes
         this.send_visible_pois_bound = send_visible_pois.bind(this);
-        this.vector_source.on("change", function () {
+        this.vector_source.on("change", () => {
             if (this.visiblePoisTimeout != null) {
                 clearTimeout(this.visiblePoisTimeout);
             }
             this.visiblePoisTimeout = setTimeout(this.send_visible_pois_bound, 50);
-        }.bind(this));
+        });
         this.map.on('moveend', this.send_visible_pois_bound);
 
         this.geojsonparser = new ol.format.GeoJSON();
     };
 
     Widget.prototype.registerPoI = function registerPoI(poi_info) {
-        var iconFeature, style;
-        iconFeature = this.vector_source.getFeatureById(poi_info.id);
-
-        if (iconFeature == null) {
-            iconFeature = new ol.Feature();
-            iconFeature.setId(poi_info.id);
-            this.vector_source.addFeature(iconFeature);
-        }
-
-        iconFeature.set('data', poi_info);
-        iconFeature.set('title', poi_info.title);
-        iconFeature.set('content', poi_info.infoWindow);
-        let minzoom = poi_info.minzoom != null ? 156543.03390625 * Math.pow(2, -poi_info.minzoom) : null;
-        iconFeature.set('minzoom', minzoom);
-        // PoI are selectable by default
-        iconFeature.set('selectable', poi_info.selectable == null || !!poi_info.selectable);
+        var iconFeature, style, geometry, marker, minzoom;
 
         if ('location' in poi_info) {
-            var geometry = this.geojsonparser.readGeometry(poi_info.location).transform('EPSG:4326', 'EPSG:3857');
-            if (iconFeature.get('selectable')) {
+            geometry = this.geojsonparser.readGeometry(poi_info.location).transform('EPSG:4326', 'EPSG:3857');
+            if (poi_info.selectable) {
                 let marker;
                 switch (geometry.getType()) {
                 case "polygon":
                     marker = new ol.geom.Point(geometry.getInteriorPoint());
-                    iconFeature.setGeometry(new ol.geom.GeometryCollection([geometry, marker]));
+                    geometry = new ol.geom.GeometryCollection([geometry, marker]);
                     break;
                 case "lineString":
                     marker = new ol.geom.Point(geometry.getCoordinateAt(0.5));
-                    iconFeature.setGeometry(new ol.geom.GeometryCollection([geometry, marker]));
-                default:
-                    iconFeature.setGeometry(geometry);
+                    geometry = new ol.geom.GeometryCollection([geometry, marker]);
+                    break;
                 }
-            } else {
-                iconFeature.setGeometry(geometry);
             }
         } else {
-            iconFeature.setGeometry(
-                new ol.geom.Point(
-                    ol.proj.transform([poi_info.currentLocation.lng, poi_info.currentLocation.lat], 'EPSG:4326', 'EPSG:3857')
-                )
+            geometry = new ol.geom.Point(
+                ol.proj.transform([poi_info.currentLocation.lng, poi_info.currentLocation.lat], 'EPSG:4326', 'EPSG:3857')
             );
         }
+
+        iconFeature = this.vector_source.getFeatureById(poi_info.id);
+        minzoom = poi_info.minzoom != null ? 156543.03390625 * Math.pow(2, -poi_info.minzoom) : null;
+        if (iconFeature == null) {
+            iconFeature = new ol.Feature({
+                geometry: geometry,
+                point: marker || geometry,
+                data: poi_info,
+                title: poi_info.title,
+                content: poi_info.infoWindow,
+                // PoI are selectable by default
+                selectable: poi_info.selectable == null || !!poi_info.selectable,
+                minzoom: minzoom
+            });
+            iconFeature.setId(poi_info.id);
+            this.vector_source.addFeature(iconFeature);
+        } else {
+            iconFeature.setProperties({
+                geometry: geometry,
+                point: marker || geometry,
+                data: poi_info,
+                title: poi_info.title,
+                content: poi_info.infoWindow,
+                // PoI are selectable by default
+                selectable: poi_info.selectable == null || !!poi_info.selectable,
+                minzoom: minzoom
+            });
+        }
+
 
         let icon = null;
         if (typeof poi_info.icon === 'string') {
@@ -311,29 +364,7 @@
         }
 
         if (icon != null && typeof icon === 'object' && icon.src != null) {
-            if (!Array.isArray(icon.anchor)) {
-                icon.anchor = [0.5, 0.5];
-            }
-
-            if (icon.opacity == null || typeof icon.opacity !== "number") {
-                icon.opacity = 1;
-            }
-
-            if (icon.scale == null || typeof icon.scale !== "number") {
-                icon.scale = 1;
-            }
-
-            style = build_basic_style.call(this, {
-                image: new ol.style.Icon(/** @type {olx.style.IconOptions} */ ({
-                    anchor: icon.anchor,
-                    anchorXUnits: icon.anchorXUnits,
-                    anchorYUnits: icon.anchorYUnits,
-                    opacity: icon.opacity,
-                    src: icon.src,
-                    scale: icon.scale
-                })),
-                style: poi_info.style
-            });
+            style = parse_marker_definition.call(this, icon, poi_info.style);
         } else if (poi_info.style != null) {
             style = build_basic_style.call(this, {style: poi_info.style});
         } else {

--- a/src/js/ol3-map-widget.js
+++ b/src/js/ol3-map-widget.js
@@ -152,7 +152,9 @@
     };
 
     var parse_marker_definition = function parse_marker_definition(icon, vector_style) {
-        if (icon == null) {
+        if (icon == null && vector_style == null) {
+            return DEFAULT_MARKER;
+        } else if (icon == null) {
             icon = {};
         }
 
@@ -363,13 +365,7 @@
             icon = Object.assign({}, poi_info.icon);
         }
 
-        if (icon != null && typeof icon === 'object' && icon.src != null) {
-            style = parse_marker_definition.call(this, icon, poi_info.style);
-        } else if (poi_info.style != null) {
-            style = build_basic_style.call(this, {style: poi_info.style});
-        } else {
-            style = DEFAULT_MARKER;
-        }
+        style = parse_marker_definition.call(this, icon, poi_info.style);
         iconFeature.setStyle(style);
 
         if (this.selected_feature === iconFeature) {

--- a/tests/js/OpenlayersWidgetSpec.js
+++ b/tests/js/OpenlayersWidgetSpec.js
@@ -414,7 +414,7 @@
                 widget.init();
                 var feature_mock = new ol.Feature();
                 spyOn(feature_mock, 'set');
-                spyOn(feature_mock, 'setGeometry');
+                spyOn(feature_mock, 'setProperties');
                 spyOn(feature_mock, 'setStyle');
 
                 spyOn(widget.vector_source, 'addFeature');
@@ -429,10 +429,15 @@
                 });
                 widget.registerPoI(poi_info);
 
-                expect(feature_mock.set).toHaveBeenCalledWith('data', poi_info);
-                expect(feature_mock.set).toHaveBeenCalledWith('title', undefined);
-                expect(feature_mock.set).toHaveBeenCalledWith('content', undefined);
-                expect(feature_mock.setGeometry).toHaveBeenCalledTimes(1);
+                expect(feature_mock.setProperties).toHaveBeenCalledWith({
+                    'geometry': jasmine.anything(),
+                    'point': jasmine.anything(),
+                    'data': poi_info,
+                    'title': undefined,
+                    'content': undefined,
+                    'selectable': true,
+                    'minzoom': null
+                });
                 expect(feature_mock.setStyle).toHaveBeenCalledTimes(1);
 
                 expect(widget.vector_source.addFeature).toHaveBeenCalledTimes(0);

--- a/tests/js/OpenlayersWidgetSpec.js
+++ b/tests/js/OpenlayersWidgetSpec.js
@@ -566,6 +566,45 @@
                     {anchor: [40, 50], opacity: 0.2, src: "https://www.example.com/image.png", scale: 0.1}
                 ));
 
+                it("Should support caching styles", () => {
+                    const hash = "vendor:domain:id";
+                    const expected = {opacity: 0.75, src: "http://localhost:9876/images/icon.png", scale: 1};
+                    const iconStyle = {
+                        anchor: [40, 50],
+                        anchorXUnits: 'pixels',
+                        anchorYUnits: 'pixels',
+                        hash: hash,
+                        src: "https://www.example.com/image.png",
+                        opacity: 0.2,
+                        scale: 0.1
+                    };
+                    widget.init();
+                    spyOn(widget.vector_source, 'addFeature');
+                    // First element, will add style to cache
+                    widget.registerPoI(deepFreeze({
+                        id: '1',
+                        data: {},
+                        location: {
+                            type: 'Point',
+                            coordinates: [0, 0]
+                        },
+                        icon: iconStyle,
+                    }));
+                    // Second PoI, will use cached style
+                    widget.registerPoI(deepFreeze({
+                        id: '1',
+                        data: {},
+                        location: {
+                            type: 'Point',
+                            coordinates: [0, 0]
+                        },
+                        icon: iconStyle,
+                    }));
+                    let feature1 = widget.vector_source.addFeature.calls.argsFor(0)[0];
+                    let feature2 = widget.vector_source.addFeature.calls.argsFor(1)[0];
+                    expect(feature1.getStyle()).toBe(feature2.getStyle());
+                });
+
             });
 
             describe("handles the minzoom option:", () => {

--- a/tests/js/OpenlayersWidgetSpec.js
+++ b/tests/js/OpenlayersWidgetSpec.js
@@ -147,6 +147,25 @@
                     expect(widget.select_feature).toHaveBeenCalledWith(feature_mock);
                 });
 
+                it("on a not selectable feature", () => {
+                    let pixel_mock = jasmine.createSpy('pixel');
+                    let feature_mock = new ol.Feature();
+                    feature_mock.set('selectable', false);
+                    widget.init();
+                    spyOn(widget, "select_feature");
+                    spyOn(widget.map, 'forEachFeatureAtPixel').and.callFake((pixel, listener) => {
+                        expect(pixel).toBe(pixel_mock);
+                        return listener(feature_mock);
+                    });
+
+                    widget.map.dispatchEvent({
+                        type: "click",
+                        pixel: pixel_mock
+                    });
+
+                    expect(widget.select_feature).not.toHaveBeenCalled();
+                });
+
                 it("on a not selected feature (with a marker)", () => {
                     let pixel_mock = jasmine.createSpy('pixel');
                     let feature_mock = new ol.Feature();
@@ -393,6 +412,44 @@
                 }));
                 expect(widget.vector_source.addFeature).toHaveBeenCalledTimes(1);
                 expect(widget.vector_source.addFeature).toHaveBeenCalledWith(jasmine.any(ol.Feature));
+            });
+
+            it("supports adding selectable PoIs (polygon)", () => {
+                widget.init();
+                spyOn(widget.vector_source, 'addFeature');
+                widget.registerPoI(deepFreeze({
+                    id: '1',
+                    data: {},
+                    selectable: true,
+                    location: {
+                        type: 'Polygon',
+                        coordinates: [[0, 0], [1, 1], [2, 0], [0, 0]]
+                    }
+                }));
+                expect(widget.vector_source.addFeature).toHaveBeenCalledTimes(1);
+                expect(widget.vector_source.addFeature).toHaveBeenCalledWith(jasmine.any(ol.Feature));
+                let feature = widget.vector_source.addFeature.calls.argsFor(0)[0];
+                // Widget should add a marker point
+                expect(feature.getGeometry().getType()).toBe("GeometryCollection");
+            });
+
+            it("supports adding selectable PoIs (linestring)", () => {
+                widget.init();
+                spyOn(widget.vector_source, 'addFeature');
+                widget.registerPoI(deepFreeze({
+                    id: '1',
+                    data: {},
+                    selectable: true,
+                    location: {
+                        type: 'LineString',
+                        coordinates: [[0, 0], [1, 1], [2, 0]]
+                    }
+                }));
+                expect(widget.vector_source.addFeature).toHaveBeenCalledTimes(1);
+                expect(widget.vector_source.addFeature).toHaveBeenCalledWith(jasmine.any(ol.Feature));
+                let feature = widget.vector_source.addFeature.calls.argsFor(0)[0];
+                // Widget should add a marker point
+                expect(feature.getGeometry().getType()).toBe("GeometryCollection");
             });
 
             it("supports adding PoIs using the deprecated currentLocation option", () => {


### PR DESCRIPTION
This PR adds support for caching PoI styles. To do so, this pull request adds a new option into the poi description to add a id/hash to the style definitions to allow the widget to cache them using this id/hash. 