### PR TITLE
Fix centerPoI endpoint when receiving empty lists

### DIFF
--- a/src/js/ol3-map-widget.js
+++ b/src/js/ol3-map-widget.js
@@ -403,6 +403,12 @@
     Widget.prototype.centerPoI = function centerPoI(poi_info) {
         var geometry, zoom;
 
+        if (poi_info.length === 0) {
+            // Just empty current selection
+            unselect.call(this, this.selected_feature);
+            return update_selected_feature.call(this, null);
+        }
+
         geometry = new ol.geom.GeometryCollection(poi_info.map((poi) => {
             var feature = this.vector_source.getFeatureById(poi.id);
             return feature.getGeometry();

--- a/tests/js/OpenlayersWidgetSpec.js
+++ b/tests/js/OpenlayersWidgetSpec.js
@@ -776,6 +776,15 @@
 
         describe("centerPoI(poi_list)", () => {
 
+            it("should work with an empty list of PoIs", () => {
+                widget.init();
+                spyOn(widget.map.getView(), 'fit').and.callThrough();
+                widget.centerPoI([]);
+
+                expect(widget.map.getView().fit).not.toHaveBeenCalled();
+                expect(MashupPlatform.widget.outputs.poiOutput.pushEvent).not.toHaveBeenCalled();
+            });
+
             it("should work with one Poi on a PoI with iconHighlighted details", () => {
                 widget.init();
                 spyOn(widget.vector_source, 'addFeature').and.callThrough();
@@ -801,9 +810,40 @@
 
                 widget.centerPoI([{id: '1'}]);
 
+                expect(widget.selected_feature).toBe(feature);
                 expect(feature.setStyle).toHaveBeenCalledTimes(1);
                 expect(widget.map.getView().fit).toHaveBeenCalledTimes(1);
                 expect(MashupPlatform.widget.outputs.poiOutput.pushEvent).toHaveBeenCalledWith(poi_info);
+            });
+
+            it("should empty current selection when passing an empty list of PoIs", () => {
+                widget.init();
+                spyOn(widget.map.getView(), 'fit').and.callThrough();
+                // TODO
+                let poi_info = deepFreeze({
+                    id: '1',
+                    data: {
+                        iconHighlighted: {
+                            src: "https://www.example.com/image.png",
+                            opacity: 0.2,
+                            scale: 0.1
+                        }
+                    },
+                    location: {
+                        type: 'Point',
+                        coordinates: [0, 0]
+                    }
+                });
+                widget.registerPoI(poi_info);
+                widget.centerPoI([{id: '1'}]);
+                widget.map.getView().fit.calls.reset();
+                MashupPlatform.widget.outputs.poiOutput.pushEvent.calls.reset();
+
+                widget.centerPoI([]);
+
+                expect(widget.map.getView().fit).not.toHaveBeenCalled();
+                expect(MashupPlatform.widget.outputs.poiOutput.pushEvent).toHaveBeenCalledWith(null);
+                expect(widget.selected_feature).toBe(null);
             });
 
             it("should work with multiple Poi", () => {


### PR DESCRIPTION
This PR updates the code handling the `centerPoI` endpoint so it not crash when passing an empty list.