### PR TITLE
Feature/improved selection management

### DIFF
--- a/src/js/ol3-map-widget.js
+++ b/src/js/ol3-map-widget.js
@@ -152,14 +152,23 @@
     };
 
     var parse_marker_definition = function parse_marker_definition(icon, vector_style) {
+        let clone = false;
         if (icon == null && vector_style == null) {
             return DEFAULT_MARKER;
         } else if (icon == null) {
             icon = {};
+        } else if (typeof icon === 'string') {
+            icon = {
+                src: icon
+            };
+        } else {
+            clone = true;
         }
 
         if (icon.hash != null && icon.hash in this.marker_cache) {
             return this.marker_cache[icon.hash];
+        } else if (clone) {
+            icon = Object.assign({}, icon);
         }
 
         if (!Array.isArray(icon.anchor)) {
@@ -359,17 +368,11 @@
             });
         }
 
-
-        let icon = null;
-        if (typeof poi_info.icon === 'string') {
-            icon = {
-                src: poi_info.icon
-            };
-        } else if (poi_info.icon != null && typeof poi_info.icon === 'object') {
-            icon = Object.assign({}, poi_info.icon);
+        if (this.selected_feature === iconFeature) {
+            style = parse_marker_definition.call(this, poi_info.iconHighlighted || poi_info.icon, poi_info.styleHighlighted || poi_info.style);
+        } else {
+            style = parse_marker_definition.call(this, poi_info.icon, poi_info.style);
         }
-
-        style = parse_marker_definition.call(this, icon, poi_info.style);
         iconFeature.setStyle(style);
 
         if (this.selected_feature === iconFeature) {
@@ -878,7 +881,7 @@
             }.bind(this), 100);
         } else {
             var poi_info = feature.get('data');
-            var style = parse_marker_definition.call(this, poi_info.iconHighlighted, poi_info.styleHighlighted || poi_info.style);
+            var style = parse_marker_definition.call(this, poi_info.iconHighlighted || poi_info.icon, poi_info.styleHighlighted || poi_info.style);
             feature.setStyle(style);
         }
     };

--- a/src/js/ol3-map-widget.js
+++ b/src/js/ol3-map-widget.js
@@ -276,6 +276,7 @@
                 update_selected_feature.call(this, null);
             } else if (feature !== this.selected_feature && this.popover != null) {
                 this.popover.hide();
+                update_selected_feature.call(this, null);
             }
         }.bind(this));
 
@@ -284,8 +285,8 @@
             if (event.dragging) {
                 if (this.popover != null) {
                     this.popover.hide();
+                    update_selected_feature.call(this, null);
                 }
-                update_selected_feature.call(this, null);
                 return;
             }
             var pixel = this.map.getEventPixel(event.originalEvent);
@@ -401,24 +402,41 @@
      * @param poi_info
      */
     Widget.prototype.centerPoI = function centerPoI(poi_info) {
-        var geometry, zoom;
-
         if (poi_info.length === 0) {
             // Just empty current selection
             unselect.call(this, this.selected_feature);
             return update_selected_feature.call(this, null);
         }
 
-        geometry = new ol.geom.GeometryCollection(poi_info.map((poi) => {
+        let geometry = new ol.geom.GeometryCollection(poi_info.map((poi) => {
             var feature = this.vector_source.getFeatureById(poi.id);
             return feature.getGeometry();
         }));
 
         // Update map view
-        zoom = parseInt(MashupPlatform.prefs.get('poiZoom'), 10);
-        this.map.getView().fit(geometry.getExtent(), {
-            maxZoom: zoom
-        });
+        let zoom = parseInt(MashupPlatform.prefs.get('poiZoom'), 10);
+        let currentZoom = this.map.getView().getZoom();
+        if (currentZoom < zoom) {
+            this.map.getView().fit(geometry.getExtent(), {
+                maxZoom: zoom
+            });
+        } else {
+            let view_extent = this.map.getView().calculateExtent(this.map.getSize());
+            let geometry_extent = geometry.getExtent();
+            if (!ol.extent.containsExtent(view_extent, geometry_extent)) {
+                let view_size = ol.extent.getSize(view_extent);
+                let geometry_size = ol.extent.getSize(geometry_extent);
+
+                if (view_size[0] < geometry_size[0] && view_size[1] < geometry_size[1]) {
+                    this.map.getView().fit(geometry.getExtent(), {
+                        maxZoom: zoom
+                    });
+                } else {
+                    let center = ol.extent.getCenter(geometry_extent);
+                    this.map.getView().setCenter(center);
+                }
+            }
+        }
 
         if (poi_info.length == 1) {
             this.select_feature(this.vector_source.getFeatureById(poi_info[0].id));
@@ -860,7 +878,7 @@
             }.bind(this), 100);
         } else {
             var poi_info = feature.get('data');
-            var style = parse_marker_definition.call(this, poi_info.iconHighlighted, poi_info.style || poi_info.styleHighlighted);
+            var style = parse_marker_definition.call(this, poi_info.iconHighlighted, poi_info.styleHighlighted || poi_info.style);
             feature.setStyle(style);
         }
     };

--- a/src/js/ol3-map-widget.js
+++ b/src/js/ol3-map-widget.js
@@ -827,7 +827,12 @@
 
         unselect.call(this, this.selected_feature);
 
+        var poi_info = feature.get('data');
+        var style = parse_marker_definition.call(this, poi_info.iconHighlighted || poi_info.icon, poi_info.styleHighlighted || poi_info.style);
+        feature.setStyle(style);
+
         update_selected_feature.call(this, feature);
+
         if (feature.get('content') != null) {
             // The feature has content to be used on a popover
             let popover = this.popover = new StyledElements.Popover({
@@ -879,10 +884,6 @@
                 update_selected_feature.call(this, feature);
                 this.popover.show(refpos);
             }.bind(this), 100);
-        } else {
-            var poi_info = feature.get('data');
-            var style = parse_marker_definition.call(this, poi_info.iconHighlighted || poi_info.icon, poi_info.styleHighlighted || poi_info.style);
-            feature.setStyle(style);
         }
     };
 

--- a/tests/js/OpenlayersWidgetSpec.js
+++ b/tests/js/OpenlayersWidgetSpec.js
@@ -510,6 +510,46 @@
                 expect(feature_mock.setStyle).toHaveBeenCalledWith(jasmine.any(Function));
             });
 
+            it("supports updating selected PoIs", () => {
+                widget.init();
+                var feature_mock = new ol.Feature();
+                spyOn(feature_mock, 'set');
+                spyOn(feature_mock, 'setProperties');
+                spyOn(feature_mock, 'setStyle');
+
+                spyOn(widget.vector_source, 'addFeature');
+                spyOn(widget.vector_source, 'getFeatureById').and.returnValue(feature_mock);
+                let poi_info = deepFreeze({
+                    id: '1',
+                    data: {},
+                    location: {
+                        type: 'Point',
+                        coordinates: [0, 0]
+                    },
+                    icon: {
+                        hash: "hash1",
+                        src: "https://www.example.com/image.png",
+                    },
+                    iconHighlighted: {
+                        hash: "hash2",
+                        src: "https://www.example.com/image.png",
+                    }
+                });
+                widget.registerPoI(poi_info);
+                widget.selected_feature = feature_mock;
+                widget.registerPoI(poi_info);
+                widget.selected_feature = null;
+                widget.registerPoI(poi_info);
+
+                expect(feature_mock.setStyle).toHaveBeenCalledTimes(3);
+                let style1 = feature_mock.setStyle.calls.argsFor(0)[0];
+                let style2 = feature_mock.setStyle.calls.argsFor(1)[0];
+                let style3 = feature_mock.setStyle.calls.argsFor(2)[0];
+
+                expect(style1).not.toBe(style2);
+                expect(style1).toBe(style3);
+            });
+
             it("sends update events when updating the selected PoI", () => {
                 var feature_mock = new ol.Feature();
                 widget.init();
@@ -658,7 +698,7 @@
                     }));
                     // Second PoI, will use cached style
                     widget.registerPoI(deepFreeze({
-                        id: '1',
+                        id: '2',
                         data: {},
                         location: {
                             type: 'Point',


### PR DESCRIPTION
Update current algorithm for updating the selected PoIs:

- [x] If current zoom level is lower than the configured one, then zoom in the view and center the view on the PoI.
- [x] Zoom out current view if the PoI representation didn't fit current view
- [x] Move current view if the zoom level is adequate, but it isn't visible on the current viewport.

Probably this is not the perfect behaviour, but I think this is better than the current one.