### PR TITLE
Allow to configure and disable the layers widget

### DIFF
--- a/src/config.xml
+++ b/src/config.xml
@@ -20,6 +20,7 @@
         <preference name="initialZoom" type="text" label="Initial Zoom Level" description="Initial zoom level. From 1 to 22, where '1' represents the furthest level and '22' the maximum zoom level." default="3" />
         <preference name="minzoom" label="Min Zoom" type="text" description="" default="4" />
         <preference name="poiZoom" label="PoI Zoom" type="text" description="Zoom level applied when centering a PoI" default="17" />
+        <preference name="layerswidget" label="Layers Widget" type="text" description="Widget to use for allowing user to switch between layers" default="" />
     </preferences>
 
     <wiring>

--- a/src/index.html
+++ b/src/index.html
@@ -9,7 +9,7 @@
     </head>
     <body>
         <div id="map" class="map"></div>
-        <div id="button" class="se-btn"><span>Layers</span></div>
+        <div id="button" class="se-btn hidden"><span>Layers</span></div>
     </body>
     <script type="text/javascript" src="js/ol3-map-widget.js"></script>
     <script type="text/javascript" src="js/main.js"></script>

--- a/src/js/ol3-map-widget.js
+++ b/src/js/ol3-map-widget.js
@@ -235,12 +235,20 @@
     };
 
     Widget.prototype.init = function init() {
-        document.getElementById('button').addEventListener('click', function (event) {
+
+        let layers_button = document.getElementById('button');
+        layers_button.addEventListener('click', (event) => {
             if (this.layers_widget == null) {
-                this.layers_widget = MashupPlatform.mashup.addWidget('CoNWeT/layer-selector/0.4', {refposition: event.target.getBoundingClientRect()});
+                this.layers_widget = MashupPlatform.mashup.addWidget(MashupPlatform.prefs.get('layerswidget').trim(), {refposition: event.target.getBoundingClientRect()});
                 this.layers_widget.outputs.layerInfoOutput.connect(MashupPlatform.widget.inputs.layerInfo);
             }
         });
+        let layers_widget_ref = MashupPlatform.prefs.get('layerswidget').trim();
+        if (layers_widget_ref === "") {
+            layers_button.classList.add('hidden');
+        } else {
+            layers_button.classList.remove('hidden');
+        }
 
         DEFAULT_MARKER = build_basic_style.call(this);
         this.base_layer = CORE_LAYERS.WIKIMEDIA;

--- a/tests/js/OpenlayersWidgetSpec.js
+++ b/tests/js/OpenlayersWidgetSpec.js
@@ -52,6 +52,7 @@
                     'poiZoom': 10,
                     'layerswidget': ''
                 },
+                inputs: ['layerInfo'],
                 outputs: ['poiListOutput', 'poiOutput']
             });
         });
@@ -121,6 +122,64 @@
                     expect(widget.map.getView().getCenter()).toEqual(ol.proj.transform([-4.4212964, 36.7212828], 'EPSG:4326', 'EPSG:3857'));
                 });
 
+            });
+
+            describe("layerswidget", () => {
+
+                it("empty", () => {
+                    MashupPlatform.prefs.set("layerswidget", "");
+
+                    widget.init();
+
+                    let layers_button = document.getElementById('button');
+                    expect(layers_button.className).toBe('se-btn hidden');
+                });
+
+                it("widget ref", () => {
+                    MashupPlatform.prefs.set("layerswidget", "CoNWeT/layer-selector/0.4");
+
+                    widget.init();
+
+                    let layers_button = document.getElementById('button');
+                    expect(layers_button.className).toBe('se-btn');
+                });
+
+                it("widget ref (click)", () => {
+                    let ref = "CoNWeT/layer-selector/0.4";
+                    MashupPlatform.prefs.set("layerswidget", ref);
+                    widget.init();
+                    MashupPlatform.mashup.addWidget.and.returnValue({
+                        outputs: {
+                            layerInfoOutput: {
+                                connect: jasmine.createSpy("connect")
+                            }
+                        }
+                    });
+
+                    let layers_button = document.getElementById('button');
+                    layers_button.click();
+                    expect(MashupPlatform.mashup.addWidget).toHaveBeenCalledWith(ref, jasmine.any(Object));
+                    expect(MashupPlatform.mashup.addWidget().outputs.layerInfoOutput.connect).toHaveBeenCalledWith(MashupPlatform.widget.inputs.layerInfo);
+                });
+
+                it("widget ref (creation is cached)", () => {
+                    let ref = "CoNWeT/layer-selector/0.4";
+                    MashupPlatform.prefs.set("layerswidget", ref);
+                    widget.init();
+                    MashupPlatform.mashup.addWidget.and.returnValue({
+                        outputs: {
+                            layerInfoOutput: {
+                                connect: jasmine.createSpy("connect")
+                            }
+                        }
+                    });
+
+                    let layers_button = document.getElementById('button');
+                    layers_button.click();
+                    MashupPlatform.mashup.addWidget.calls.reset();
+                    layers_button.click();
+                    expect(MashupPlatform.mashup.addWidget).not.toHaveBeenCalled();
+                });
             });
 
         });

--- a/tests/js/OpenlayersWidgetSpec.js
+++ b/tests/js/OpenlayersWidgetSpec.js
@@ -49,7 +49,8 @@
                 prefs: {
                     'initialCenter': '',
                     'initialZoom': '',
-                    'poiZoom': 10
+                    'poiZoom': 10,
+                    'layerswidget': ''
                 },
                 outputs: ['poiListOutput', 'poiOutput']
             });


### PR DESCRIPTION
This PR changes current widget behaviour to allow to configure the widget to be used for switching between the different layers. This way, it is possible to develop custom widgets for that purpose. In addition to this, it is also possible to disable layer switching at all by providing an empty value for the layer widget preference.