### PR TITLE
Fix proj4.js not found

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -29,6 +29,7 @@ module.exports = function (grunt) {
         bower: {
             install: {
                 options: {
+                    copy: true,
                     layout: function (type, component, source) {
                         return type;
                     },

--- a/src/config.xml
+++ b/src/config.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<widget xmlns="http://wirecloud.conwet.fi.upm.es/ns/macdescription/1" vendor="CoNWeT" name="ol3-map" version="1.1.0">
+<widget xmlns="http://wirecloud.conwet.fi.upm.es/ns/macdescription/1" vendor="CoNWeT" name="ol3-map" version="1.1.1">
     <details>
         <title>OpenLayers Map</title>
         <email>wirecloud@conwet.com</email>

--- a/src/doc/changelog.md
+++ b/src/doc/changelog.md
@@ -1,3 +1,8 @@
+## v1.1.1 (2019-02-28)
+
+- Fix proj4.js not being packaged into the widget. See #16.
+
+
 ## v1.1.0 (2019-02-08)
 
 - Add a new preference for configuring the widget to be used for switching


### PR DESCRIPTION
Version 1.1.0 fails loading proj4.js with the following error:

```
Failed to load resource: the server responded with a status of 404 ()
```

This is caused by a change in newer versions of `grunt-contrib-bower` that makes proj4.js being excluded from the packaged widget. This PR fixes it by adding a `copy: true` option on the bower task.