### PR TITLE
Allow poiInputCenter endpoint receive null

### DIFF
--- a/src/config.xml
+++ b/src/config.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<widget xmlns="http://wirecloud.conwet.fi.upm.es/ns/macdescription/1" vendor="CoNWeT" name="ol3-map" version="1.1.4a1">
+<widget xmlns="http://wirecloud.conwet.fi.upm.es/ns/macdescription/1" vendor="CoNWeT" name="ol3-map" version="1.1.4a2">
     <details>
         <title>OpenLayers Map</title>
         <email>wirecloud@conwet.com</email>

--- a/src/doc/changelog.md
+++ b/src/doc/changelog.md
@@ -1,6 +1,7 @@
 ## v1.1.4 (2019-XX-XX)
 
 - Fix getPixelFromCoordinate function. See #23 and #24.
+- Allow poiInputCenter endpoint receive null. See #25.
 
 
 ## v1.1.3 (2019-10-22)

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -74,6 +74,10 @@
     });
 
     MashupPlatform.wiring.registerCallback('poiInputCenter', (poi_info) => {
+        if (poi_info == null) {
+            poi_info = [];
+        }
+
         poi_info = parseInputEndpointData(poi_info);
 
         if (!Array.isArray(poi_info)) {


### PR DESCRIPTION
I'd like to make a dashboard that has two ol3-map widgets. They are connected as the following figure. A **'PoI selected'** endpoint of the first ol3-map is connected to a **'Center PoI'** endpoint of the second ol3-map. A PoI selected in the first ol3-map is shown at a center position in the second ol3-map.

![ol3-1](https://user-images.githubusercontent.com/31051904/68936636-547f8980-07de-11ea-98b9-797d207bc6de.png)

![ol3-2](https://user-images.githubusercontent.com/31051904/68936643-577a7a00-07de-11ea-8eee-6e8fa45f51c6.png)

In current implementation, The EndpointTypeError is occuerd when poiInputCenter endpoint receive null. This PR allows poiInputCenter endpoint receive null by replacing null to empty list. And it unselects a popup. The live demo is the following link.
[https://mashup.lab.fisuda.jp/letsfiware/poiinputcenter#view=workspace&tab=tab](https://mashup.lab.fisuda.jp/letsfiware/poiinputcenter#view=workspace&tab=tab)

It would be great if you could find the time to review this PR.

Thank you.