### PR TITLE
Add a "maxzoom" option

### DIFF
--- a/src/doc/userguide.md
+++ b/src/doc/userguide.md
@@ -78,8 +78,8 @@ Map viewer widget using OpenLayers. It can receive Layers or Point of Interest d
     - `infoWindow`: content (using HTML) associated with the PoI.
     - `location` (required if `currentLocation` not used): a GeoJSON geometry.
       e.g. `{"type": "Point", "coordinates": [125.6, 10.1]}`
-    - `minzoom` (integer): Minimum zoom level to display this PoI. Leave it
-      empty to display the PoI at any zoom level.
+    - `minzoom` (integer): Minimum zoom level to display this PoI.
+    - `maxzoom` (integer): Maximum zoom level to display this PoI.
     - `selectable` (boolean): `true` if the user should be able to select this
       PoI (default behaviour).
     - `style`: Style to use for rendering. Supported options:

--- a/src/js/ol3-map-widget.js
+++ b/src/js/ol3-map-widget.js
@@ -154,8 +154,11 @@
             }
 
             var minzoom = feature.get('minzoom');
+            var maxzoom = feature.get('maxzoom');
 
             if (minzoom != null && resolution > minzoom) {
+                return null;
+            } else if (maxzoom != null && resolution < maxzoom) {
                 return null;
             }
 
@@ -367,7 +370,7 @@
     };
 
     Widget.prototype.registerPoI = function registerPoI(poi_info) {
-        var iconFeature, style, geometry, marker, minzoom;
+        var iconFeature, style, geometry, marker, minzoom, maxzoom;
 
         if ('location' in poi_info) {
             geometry = this.geojsonparser.readGeometry(poi_info.location).transform('EPSG:4326', 'EPSG:3857');
@@ -391,6 +394,7 @@
 
         iconFeature = this.vector_source.getFeatureById(poi_info.id);
         minzoom = poi_info.minzoom != null ? this.map.getView().getResolutionForZoom(poi_info.minzoom) : null;
+        maxzoom = poi_info.maxzoom != null ? this.map.getView().getResolutionForZoom(poi_info.maxzoom) : null;
         if (iconFeature == null) {
             iconFeature = new ol.Feature({
                 geometry: geometry,
@@ -400,7 +404,8 @@
                 content: poi_info.infoWindow,
                 // PoI are selectable by default
                 selectable: poi_info.selectable == null || !!poi_info.selectable,
-                minzoom: minzoom
+                minzoom: minzoom,
+                maxzoom: maxzoom
             });
             iconFeature.setId(poi_info.id);
             this.vector_source.addFeature(iconFeature);
@@ -413,7 +418,8 @@
                 content: poi_info.infoWindow,
                 // PoI are selectable by default
                 selectable: poi_info.selectable == null || !!poi_info.selectable,
-                minzoom: minzoom
+                minzoom: minzoom,
+                maxzoom: maxzoom
             });
         }
 

--- a/tests/js/OpenlayersWidgetSpec.js
+++ b/tests/js/OpenlayersWidgetSpec.js
@@ -648,13 +648,14 @@
                 widget.registerPoI(poi_info);
 
                 expect(feature_mock.setProperties).toHaveBeenCalledWith({
-                    'geometry': jasmine.anything(),
-                    'point': jasmine.anything(),
-                    'data': poi_info,
-                    'title': undefined,
-                    'content': undefined,
-                    'selectable': true,
-                    'minzoom': null
+                    geometry: jasmine.anything(),
+                    point: jasmine.anything(),
+                    data: poi_info,
+                    title: undefined,
+                    content: undefined,
+                    selectable: true,
+                    minzoom: null,
+                    maxzoom: null
                 });
                 expect(feature_mock.setStyle).toHaveBeenCalledTimes(1);
 
@@ -889,6 +890,33 @@
 
                 it("displays the PoI if the zoom level is greather than the configured one", test(2.388657133911758, true));
                 it("hides the PoI if the zoom level is lower than the configured one", test(152.8740565703525, false));
+
+            });
+
+            describe("handles the maxzoom option:", () => {
+                const test = function (resolution, displayed) {
+                    return () => {
+                        widget.init();
+                        spyOn(widget.vector_source, 'addFeature');
+                        widget.registerPoI(deepFreeze({
+                            id: '1',
+                            data: {},
+                            location: {
+                                type: 'Point',
+                                coordinates: [0, 0]
+                            },
+                            maxzoom: 13
+                        }));
+                        expect(widget.vector_source.addFeature).toHaveBeenCalledTimes(1);
+                        expect(widget.vector_source.addFeature).toHaveBeenCalledWith(jasmine.any(ol.Feature));
+                        let feature = widget.vector_source.addFeature.calls.argsFor(0)[0];
+                        let fstyle = feature.getStyle()(feature, resolution);
+                        expect(fstyle).toEqual(displayed ? jasmine.any(ol.style.Style) : null);
+                    };
+                };
+
+                it("hides the PoI if the zoom level is greather than the configured one", test(2.388657133911758, false));
+                it("displays the PoI if the zoom level is lower than the configured one", test(152.8740565703525, true));
 
             });
 


### PR DESCRIPTION
This PR adds support for configuring the max zoom level to which display a poi in a similar way to the minzoom option currently supported.