### PR TITLE
Improve layer configurability

### DIFF
--- a/src/config.xml
+++ b/src/config.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<widget xmlns="http://wirecloud.conwet.fi.upm.es/ns/macdescription/1" vendor="CoNWeT" name="ol3-map" version="1.1.4a5">
+<widget xmlns="http://wirecloud.conwet.fi.upm.es/ns/macdescription/1" vendor="CoNWeT" name="ol3-map" version="1.2.0a2">
     <details>
         <title>OpenLayers Map</title>
         <email>wirecloud@conwet.com</email>
@@ -29,7 +29,7 @@
     </preferences>
 
     <wiring>
-        <inputendpoint name="layerInfo" type="text" label="Layer Info" description="Add or remove layers to the map, in addition to changing its base layer." actionlabel="Update Layers" friendcode="wms-layer-command"/>
+        <inputendpoint name="layerInfo" type="text" label="Layer Info" description="Add or remove layers to the map, in addition to changing its base layer." actionlabel="Update Layers" friendcode="ol-layer-command wms-layer-command"/>
         <inputendpoint name="poiInput" type="text" label="Insert/Update PoI" description="Insert or update a Point of Interest." actionlabel="Map Viewer Insert/Update PoI" friendcode="poi poi-list"/>
         <inputendpoint name="poiInputCenter" type="text" label="Center PoI" description="Insert or update a Point of Interest and center the map on it." actionlabel="Center" friendcode="poi poi-list" />
         <inputendpoint name="deletePoiInput" type="text" label="Delete PoI" description="Removes one or more point of interests from the map." actionlabel="Remove" friendcode="poi poi-list" />

--- a/src/doc/changelog.md
+++ b/src/doc/changelog.md
@@ -3,6 +3,12 @@
 - Fix getPixelFromCoordinate function. See #23 and #24.
 - Allow poiInputCenter endpoint receive null. See #25.
 - Add clustering support (enabled through a preference). See #27.
+- Improve layer configurability. See #28.
+    - Added support for the following general options: `opacity`, `visible`,
+      `viewMaxZoom` and `viewMinZoom`
+    - `extent` option is now transformed from `EPSG:4623`
+    - Added a new command for updating layer options. Current available options
+      for those updates are: `opacity`, `visible` and `url`.
 
 
 ## v1.1.3 (2019-10-22)

--- a/src/doc/userguide.md
+++ b/src/doc/userguide.md
@@ -9,6 +9,8 @@ Map viewer widget using OpenLayers. It can receive Layers or Point of Interest d
 - **Initial Location**: Decimal coordinates where map will be centered on load (e.g. `52, 5`). Leave this setting empty if you don't want to center the map at init. Remember to change the initial zoom level if you provide an initial location.
 - **Initial Zoom Level**: Initial zoom level. From 1 to 22, where '1' represents the furthest level and '22' the maximum zoom level.
 - **Min Zoom**: Minimal zoom level.
+- **Layers Widget**: Widget to use for allowing user to switch between layers.
+- **Use Clustering**: Mark this option to use clustering for displaying map features.
 
 
 ## Wiring
@@ -20,13 +22,16 @@ Map viewer widget using OpenLayers. It can receive Layers or Point of Interest d
   base layer.
   The Layer Info endpoint receives a JSON with two fields: `action` and `data`
   - `action`: This field indicates the action to be executed with a layer. There
-    are three available actions:
+    are four available actions:
     - `addLayer`: Adds a layer to the map. This action requires the `id` data
       field to be set.
     - `removeLayer`: Removes a layer from the map. This action requires the `id`
       data field to be set.
     - `setBaseLayer`: Change the base layer of the map. This action requires the
       `id` data field to be set.
+    - `updateLayer`: Updates a layer from the map. This action requires the `id`
+      data field to be set. Current options available for updating are:
+      `opacity`, `visible` and `url`.
   - `data`: This field contains all the data needed to identify to which layer
     the action will be performed, and, in the case of the addLayer action, to
     define and configure the layer.

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -50,7 +50,7 @@
             commands = [commands];
         }
 
-        if (commands.some((command) => {return command == null || ["addLayer", "removeLayer", "setBaseLayer"].indexOf(command.action) === -1;})) {
+        if (commands.some((command) => {return command == null || ["addLayer", "updateLayer", "removeLayer", "setBaseLayer"].indexOf(command.action) === -1;})) {
             throw new MashupPlatform.wiring.EndpointValueError("Invalid command action");
         }
 
@@ -58,6 +58,9 @@
             switch (command.action) {
             case "addLayer":
                 widget.addLayer(command.data);
+                break;
+            case "updateLayer":
+                widget.updateLayer(command.data);
                 break;
             case "removeLayer":
                 widget.removeLayer(command.data);

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -43,22 +43,30 @@
         }
     });
 
-    MashupPlatform.wiring.registerCallback('layerInfo', (command_info) => {
-        command_info = parseInputEndpointData(command_info);
+    MashupPlatform.wiring.registerCallback('layerInfo', (commands) => {
+        commands = parseInputEndpointData(commands);
 
-        switch (command_info.action) {
-        case "addLayer":
-            widget.addLayer(command_info.data);
-            break;
-        case "removeLayer":
-            widget.removeLayer(command_info.data);
-            break;
-        case "setBaseLayer":
-            widget.setBaseLayer(command_info.data);
-            break;
-        default:
-            throw new MashupPlatform.wiring.EndpointValueError();
+        if (!Array.isArray(commands)) {
+            commands = [commands];
         }
+
+        if (commands.some((command) => {return command == null || ["addLayer", "removeLayer", "setBaseLayer"].indexOf(command.action) === -1;})) {
+            throw new MashupPlatform.wiring.EndpointValueError("Invalid command action");
+        }
+
+        commands.forEach((command) => {
+            switch (command.action) {
+            case "addLayer":
+                widget.addLayer(command.data);
+                break;
+            case "removeLayer":
+                widget.removeLayer(command.data);
+                break;
+            case "setBaseLayer":
+                widget.setBaseLayer(command.data);
+                break;
+            }
+        });
     });
 
     MashupPlatform.wiring.registerCallback('poiInput', (poi_info) => {

--- a/src/js/ol3-map-widget.js
+++ b/src/js/ol3-map-widget.js
@@ -864,10 +864,10 @@
         const options = {
             source: new ol.source.Stamen({
                 layer: layer_info.layer,
-                url: build_compatible_url(layer_info.url, false),
                 maxZoom: layer_info.maxZoom,
                 minZoom: layer_info.minZoom,
-                opaque: layer_info.opaque
+                opaque: layer_info.opaque,
+                url: build_compatible_url(layer_info.url, false)
             })
         };
 
@@ -878,10 +878,10 @@
         const options = {
             source: new ol.source.BingMaps({
                 cacheSize: layer_info.cacheSize,
-                hidpi: layer_info.hidpi,
                 culture: layer_info.culture,
-                key: layer_info.key,
+                hidpi: layer_info.hidpi,
                 imagerySet: layer_info.imagerySet,
+                key: layer_info.key,
                 maxZoom: layer_info.maxZoom,
                 reprojectionErrorThreshold: layer_info.reprojectionErrorThreshold,
                 wrapX: layer_info.wrapX
@@ -894,17 +894,17 @@
     var addCartoDBLayer = function addCartoDBLayer(layer_info) {
         const options = {
             source: new ol.source.CartoDB({
+                account: layer_info.account,
                 attributions: layer_info.attributions,
                 cacheSize: layer_info.cacheSize,
+                config: layer_info.config,
                 crossOrigin: layer_info.crossOrigin,
                 logo: layer_info.logo,
-                projection: layer_info.projection,
+                map: layer_info.map,
                 maxZoom: layer_info.maxZoom,
                 minZoom: layer_info.minZoom,
-                wrapX: layer_info.wrapX,
-                config: layer_info.config,
-                map: layer_info.map,
-                account: layer_info.account
+                projection: layer_info.projection,
+                wrapX: layer_info.wrapX
             })
         };
 
@@ -915,17 +915,18 @@
         const options = {
             source: new ol.source.WMTS({
                 cacheSize: layer_info.cacheSize,
+                format: layer_info.format,
                 logo: layer_info.logo,
+                matrixSet: layer_info.matrixSet,
                 projection: layer_info.projection,
                 reprojectionErrorThreshold: layer_info.reprojectionErrorThreshold,
                 requestEncoding: layer_info.requestEncoding,
                 layer: layer_info.layer,
                 style: layer_info.style,
                 tilePixelRatio: layer_info.tilePixelRatio,
-                version: layer_info.version,
-                format: layer_info.format,
-                matrixSet: layer_info.matrixSet,
+                transition: layer_info.transition,
                 url: build_compatible_url(layer_info.url, true),
+                version: layer_info.version,
                 wrapX: layer_info.wrapX
             })
         };
@@ -939,8 +940,9 @@
                 cacheSize: layer_info.cacheSize,
                 logo: layer_info.logo,
                 projection: layer_info.projection,
-                url: build_compatible_url(layer_info.url, false),
                 tierSizeCalculation: layer_info.tierSizeCalculation,
+                transition: layer_info.transition,
+                url: build_compatible_url(layer_info.url, false),
                 size: layer_info.size
             })
         };

--- a/src/js/ol3-map-widget.js
+++ b/src/js/ol3-map-widget.js
@@ -642,6 +642,9 @@
     };
 
     const build_layer = function build_layer(layer_class, options, layer_info) {
+        if (layer_info.extent) {
+            options.extent = ol.proj.transformExtent(layer_info.extent, 'EPSG:4326', 'EPSG:3857');
+        }
         if (typeof layer_info.viewMaxZoom === "number") {
             options.minResolution = this.map.getView().getResolutionForZoom(layer_info.viewMaxZoom);
         }
@@ -663,7 +666,6 @@
         }
 
         let options = {
-            extent: layer_info.extent,
             crossOrigin: 'anonymous',
             opacity: layer_info.opacity,
             source: new ol.source.ImageWMS({
@@ -684,7 +686,6 @@
 
     var addImageArcGISRestLayer = function addImageArcGISRestLayer(layer_info) {
         let options = {
-            extent: layer_info.extent,
             crossOrigin: 'anonymous',
             opacity: layer_info.opacity,
             source: new ol.source.ImageArcGISRest({
@@ -703,7 +704,6 @@
 
     var addImageMapGuideLayer = function addImageMapGuideLayer(layer_info) {
         let options = {
-            extent: layer_info.extent,
             crossOrigin: 'anonymous',
             opacity: layer_info.opacity,
             source: new ol.source.ImageMapGuide({
@@ -722,7 +722,6 @@
 
     var addImageStaticLayer = function addImageStaticLayer(layer_info) {
         let options = {
-            extent: layer_info.extent,
             crossOrigin: 'anonymous',
             opacity: layer_info.opacity,
             source: new ol.source.ImageStatic({
@@ -740,7 +739,6 @@
 
     var addVectorLayer = function addVectorLayer(layer_info) {
         let options = {
-            extent: layer_info.extent,
             crossOrigin: 'anonymous',
             opacity: layer_info.opacity,
             source: new ol.source.Vector({
@@ -765,7 +763,6 @@
 
     var addVectorTileLayer = function addVectorTileLayer(layer_info) {
         let options = {
-            extent: layer_info.extent,
             crossOrigin: 'anonymous',
             opacity: layer_info.opacity,
             source: new ol.source.VectorTile({
@@ -787,7 +784,6 @@
 
     var addOSMLayer = function addOSMLayer(layer_info) {
         let options = {
-            extent: layer_info.extent,
             opacity: layer_info.opacity,
             source: new ol.source.OSM({
                 wrapX: layer_info.wrapX,
@@ -815,7 +811,6 @@
         }
 
         let options = {
-            extent: layer_info.extent,
             opacity: layer_info.opacity,
             source: new ol.source.TileWMS({
                 cacheSize: layer_info.cacheSize,
@@ -835,7 +830,6 @@
 
     var addTileJSONLayer = function addTileJSONLayer(layer_info) {
         let options = {
-            extent: layer_info.extent,
             opacity: layer_info.opacity,
             source: new ol.source.TileJSON({
                 cacheSize: layer_info.cacheSize,
@@ -854,7 +848,6 @@
 
     var addTileUTFGridLayer = function addTileUTFGridLayer(layer_info) {
         let options = {
-            extent: layer_info.extent,
             opacity: layer_info.opacity,
             source: new ol.source.TileUTFGrid({
                 jsonp: layer_info.jsonp,
@@ -870,7 +863,6 @@
 
     var addXYZLayer = function addXYZLayer(layer_info) {
         const options = {
-            extent: layer_info.extent,
             opacity: layer_info.opacity,
             preload: layer_info.preload,
             source: new ol.source.XYZ({
@@ -892,7 +884,6 @@
 
     var addStamenLayer = function addStamenLayer(layer_info) {
         const options = {
-            extent: layer_info.extent,
             opacity: layer_info.opacity,
             source: new ol.source.Stamen({
                 layer: layer_info.layer,
@@ -909,7 +900,6 @@
 
     const addBingMapsLayer = function addBingMapsLayer(layer_info) {
         const options = {
-            extent: layer_info.extent,
             opacity: layer_info.opacity,
             source: new ol.source.BingMaps({
                 cacheSize: layer_info.cacheSize,
@@ -929,7 +919,6 @@
 
     var addCartoDBLayer = function addCartoDBLayer(layer_info) {
         const options = {
-            extent: layer_info.extent,
             opacity: layer_info.opacity,
             source: new ol.source.CartoDB({
                 attributions: layer_info.attributions,
@@ -952,7 +941,6 @@
 
     var addWMTSLayer = function addWMTSLayer(layer_info) {
         const options = {
-            extent: layer_info.extent,
             opacity: layer_info.opacity,
             source: new ol.source.WMTS({
                 cacheSize: layer_info.cacheSize,
@@ -977,7 +965,6 @@
 
     var addZoomifyLayer = function addZoomifyLayer(layer_info) {
         const options = {
-            extent: layer_info.extent,
             opacity: layer_info.opacity,
             source: new ol.source.Zoomify({
                 cacheSize: layer_info.cacheSize,

--- a/src/js/ol3-map-widget.js
+++ b/src/js/ol3-map-widget.js
@@ -669,7 +669,6 @@
         }
 
         const options = {
-            crossOrigin: 'anonymous',
             source: new ol.source.ImageWMS({
                 url: build_compatible_url(layer_info.url, true),
                 params: params,
@@ -687,7 +686,6 @@
 
     var addImageArcGISRestLayer = function addImageArcGISRestLayer(layer_info) {
         const options = {
-            crossOrigin: 'anonymous',
             source: new ol.source.ImageArcGISRest({
                 url: build_compatible_url(layer_info.url, true),
                 crossOrigin: layer_info.crossOrigin,
@@ -703,7 +701,6 @@
 
     var addImageMapGuideLayer = function addImageMapGuideLayer(layer_info) {
         const options = {
-            crossOrigin: 'anonymous',
             source: new ol.source.ImageMapGuide({
                 url: build_compatible_url(layer_info.url, true),
                 displayDpi: layer_info.displayDpi,
@@ -719,7 +716,6 @@
 
     var addImageStaticLayer = function addImageStaticLayer(layer_info) {
         const options = {
-            crossOrigin: 'anonymous',
             source: new ol.source.ImageStatic({
                 url: build_compatible_url(layer_info.url, true),
                 crossOrigin: layer_info.crossOrigin,
@@ -734,8 +730,8 @@
 
     var addVectorLayer = function addVectorLayer(layer_info) {
         const options = {
-            crossOrigin: 'anonymous',
             source: new ol.source.Vector({
+                crossOrigin: layer_info.crossOrigin,
                 format: addFormat(layer_info),
                 wrapX: layer_info.wrapX,
                 // Vector source does not require an url
@@ -756,9 +752,9 @@
 
     var addVectorTileLayer = function addVectorTileLayer(layer_info) {
         const options = {
-            crossOrigin: 'anonymous',
             source: new ol.source.VectorTile({
                 cacheSize: layer_info.cacheSize,
+                crossOrigin: layer_info.crossOrigin,
                 format: addFormat(layer_info),
                 logo: layer_info.logo,
                 overlaps: layer_info.overlaps,

--- a/src/js/ol3-map-widget.js
+++ b/src/js/ol3-map-widget.js
@@ -642,6 +642,9 @@
     };
 
     const build_layer = function build_layer(layer_class, options, layer_info) {
+        options.opacity = layer_info.opacity;
+        options.visible = layer_info.visible != null ? layer_info.visible : true;
+
         if (layer_info.extent) {
             options.extent = ol.proj.transformExtent(layer_info.extent, 'EPSG:4326', 'EPSG:3857');
         }
@@ -665,9 +668,8 @@
             params.LAYERS = layer_info.id;
         }
 
-        let options = {
+        const options = {
             crossOrigin: 'anonymous',
-            opacity: layer_info.opacity,
             source: new ol.source.ImageWMS({
                 url: build_compatible_url(layer_info.url, true),
                 params: params,
@@ -677,17 +679,15 @@
                 serverType: layer_info.serverType,
                 logo: layer_info.logo,
                 ratio: layer_info.ratio
-            }),
-            visible: layer_info.visible != null ? layer_info.visible : true
+            })
         };
 
         return build_layer.call(this, "Image", options, layer_info);
     };
 
     var addImageArcGISRestLayer = function addImageArcGISRestLayer(layer_info) {
-        let options = {
+        const options = {
             crossOrigin: 'anonymous',
-            opacity: layer_info.opacity,
             source: new ol.source.ImageArcGISRest({
                 url: build_compatible_url(layer_info.url, true),
                 crossOrigin: layer_info.crossOrigin,
@@ -695,17 +695,15 @@
                 logo: layer_info.logo,
                 ratio: layer_info.ratio,
                 projection: layer_info.projection
-            }),
-            visible: layer_info.visible != null ? layer_info.visible : true
+            })
         };
 
         return build_layer.call(this, "Image", options, layer_info);
     };
 
     var addImageMapGuideLayer = function addImageMapGuideLayer(layer_info) {
-        let options = {
+        const options = {
             crossOrigin: 'anonymous',
-            opacity: layer_info.opacity,
             source: new ol.source.ImageMapGuide({
                 url: build_compatible_url(layer_info.url, true),
                 displayDpi: layer_info.displayDpi,
@@ -713,34 +711,30 @@
                 hidpi: layer_info.hidpi,
                 useOverlay: layer_info.useOverlay,
                 ratio: layer_info.ratio
-            }),
-            visible: layer_info.visible != null ? layer_info.visible : true
+            })
         };
 
         return build_layer.call(this, "Image", options, layer_info);
     };
 
     var addImageStaticLayer = function addImageStaticLayer(layer_info) {
-        let options = {
+        const options = {
             crossOrigin: 'anonymous',
-            opacity: layer_info.opacity,
             source: new ol.source.ImageStatic({
                 url: build_compatible_url(layer_info.url, true),
                 crossOrigin: layer_info.crossOrigin,
                 logo: layer_info.logo,
                 imageExtent: layer_info.imageExtent,
                 projection: layer_info.projection
-            }),
-            visible: layer_info.visible != null ? layer_info.visible : true
+            })
         };
 
         return build_layer.call(this, "Image", options, layer_info);
     };
 
     var addVectorLayer = function addVectorLayer(layer_info) {
-        let options = {
+        const options = {
             crossOrigin: 'anonymous',
-            opacity: layer_info.opacity,
             source: new ol.source.Vector({
                 format: addFormat(layer_info),
                 wrapX: layer_info.wrapX,
@@ -754,17 +748,15 @@
                     color: 'rgba(0, 0, 255, 1.0)',
                     width: 2
                 })
-            }),
-            visible: layer_info.visible != null ? layer_info.visible : true
+            })
         };
 
         return build_layer.call(this, "Vector", options, layer_info);
     };
 
     var addVectorTileLayer = function addVectorTileLayer(layer_info) {
-        let options = {
+        const options = {
             crossOrigin: 'anonymous',
-            opacity: layer_info.opacity,
             source: new ol.source.VectorTile({
                 cacheSize: layer_info.cacheSize,
                 format: addFormat(layer_info),
@@ -775,15 +767,14 @@
                 tileClass: layer_info.tileClass,
                 url: build_compatible_url(layer_info.url, true),
                 wrapX: layer_info.wrapX
-            }),
-            visible: layer_info.visible != null ? layer_info.visible : true
+            })
         };
 
         return build_layer.call(this, "Tile", options, layer_info);
     };
 
     var addOSMLayer = function addOSMLayer(layer_info) {
-        let options = {
+        const options = {
             opacity: layer_info.opacity,
             source: new ol.source.OSM({
                 wrapX: layer_info.wrapX,
@@ -792,8 +783,7 @@
                 maxZoom: layer_info.maxZoom,
                 opaque: layer_info.opaque,
                 reprojectionErrorThreshold: layer_info.reprojectionErrorThreshold
-            }),
-            visible: layer_info.visible != null ? layer_info.visible : true
+            })
         };
 
         return build_layer.call(this, "Tile", options, layer_info);
@@ -810,8 +800,7 @@
             params.LAYERS = layer_info.id;
         }
 
-        let options = {
-            opacity: layer_info.opacity,
+        const options = {
             source: new ol.source.TileWMS({
                 cacheSize: layer_info.cacheSize,
                 crossOrigin: layer_info.crossOrigin,
@@ -821,16 +810,14 @@
                 params: layer_info.params,
                 url: build_compatible_url(layer_info.url, true),
                 wrapX: layer_info.wrapX
-            }),
-            visible: layer_info.visible != null ? layer_info.visible : true
+            })
         };
 
         return build_layer.call(this, "Tile", options, layer_info);
     };
 
     var addTileJSONLayer = function addTileJSONLayer(layer_info) {
-        let options = {
-            opacity: layer_info.opacity,
+        const options = {
             source: new ol.source.TileJSON({
                 cacheSize: layer_info.cacheSize,
                 crossOrigin: layer_info.crossOrigin,
@@ -839,23 +826,20 @@
                 tileJSON: layer_info.tileJSON,
                 url: build_compatible_url(layer_info.url, true),
                 wrapX: layer_info.wrapX
-            }),
-            visible: layer_info.visible != null ? layer_info.visible : true
+            })
         };
 
         return build_layer.call(this, "Tile", options, layer_info);
     };
 
     var addTileUTFGridLayer = function addTileUTFGridLayer(layer_info) {
-        let options = {
-            opacity: layer_info.opacity,
+        const options = {
             source: new ol.source.TileUTFGrid({
                 jsonp: layer_info.jsonp,
                 preemptive: layer_info.preemptive,
                 tileJSON: layer_info.tileJSON,
                 url: build_compatible_url(layer_info.url, false),
-            }),
-            visible: layer_info.visible != null ? layer_info.visible : true
+            })
         };
 
         return build_layer.call(this, "Tile", options, layer_info);
@@ -863,7 +847,6 @@
 
     var addXYZLayer = function addXYZLayer(layer_info) {
         const options = {
-            opacity: layer_info.opacity,
             preload: layer_info.preload,
             source: new ol.source.XYZ({
                 cacheSize: layer_info.cacheSize,
@@ -875,8 +858,7 @@
                 tilePixelRatio: layer_info.tilePixelRatio,
                 tileSize: layer_info.tileSize,
                 transition: layer_info.transition
-            }),
-            visible: layer_info.visible != null ? layer_info.visible : true
+            })
         };
 
         return build_layer.call(this, "Tile", options, layer_info);
@@ -884,15 +866,13 @@
 
     var addStamenLayer = function addStamenLayer(layer_info) {
         const options = {
-            opacity: layer_info.opacity,
             source: new ol.source.Stamen({
                 layer: layer_info.layer,
                 url: build_compatible_url(layer_info.url, false),
                 maxZoom: layer_info.maxZoom,
                 minZoom: layer_info.minZoom,
                 opaque: layer_info.opaque
-            }),
-            visible: layer_info.visible != null ? layer_info.visible : true
+            })
         };
 
         return build_layer.call(this, "Tile", options, layer_info);
@@ -900,7 +880,6 @@
 
     const addBingMapsLayer = function addBingMapsLayer(layer_info) {
         const options = {
-            opacity: layer_info.opacity,
             source: new ol.source.BingMaps({
                 cacheSize: layer_info.cacheSize,
                 hidpi: layer_info.hidpi,
@@ -910,8 +889,7 @@
                 maxZoom: layer_info.maxZoom,
                 reprojectionErrorThreshold: layer_info.reprojectionErrorThreshold,
                 wrapX: layer_info.wrapX
-            }),
-            visible: layer_info.visible != null ? layer_info.visible : true
+            })
         };
 
         return build_layer.call(this, "Tile", options, layer_info);
@@ -919,7 +897,6 @@
 
     var addCartoDBLayer = function addCartoDBLayer(layer_info) {
         const options = {
-            opacity: layer_info.opacity,
             source: new ol.source.CartoDB({
                 attributions: layer_info.attributions,
                 cacheSize: layer_info.cacheSize,
@@ -932,8 +909,7 @@
                 config: layer_info.config,
                 map: layer_info.map,
                 account: layer_info.account
-            }),
-            visible: layer_info.visible != null ? layer_info.visible : true
+            })
         };
 
         return build_layer.call(this, "Tile", options, layer_info);
@@ -941,7 +917,6 @@
 
     var addWMTSLayer = function addWMTSLayer(layer_info) {
         const options = {
-            opacity: layer_info.opacity,
             source: new ol.source.WMTS({
                 cacheSize: layer_info.cacheSize,
                 logo: layer_info.logo,
@@ -956,8 +931,7 @@
                 matrixSet: layer_info.matrixSet,
                 url: build_compatible_url(layer_info.url, true),
                 wrapX: layer_info.wrapX
-            }),
-            visible: layer_info.visible != null ? layer_info.visible : true
+            })
         };
 
         return build_layer.call(this, "Tile", options, layer_info);
@@ -965,7 +939,6 @@
 
     var addZoomifyLayer = function addZoomifyLayer(layer_info) {
         const options = {
-            opacity: layer_info.opacity,
             source: new ol.source.Zoomify({
                 cacheSize: layer_info.cacheSize,
                 logo: layer_info.logo,
@@ -973,8 +946,7 @@
                 url: build_compatible_url(layer_info.url, false),
                 tierSizeCalculation: layer_info.tierSizeCalculation,
                 size: layer_info.size
-            }),
-            visible: layer_info.visible != null ? layer_info.visible : true
+            })
         };
 
         return build_layer.call(this, "Tile", options, layer_info);

--- a/tests/js/OpenlayersWidgetSpec.js
+++ b/tests/js/OpenlayersWidgetSpec.js
@@ -1810,7 +1810,7 @@
                 const layer_mock = {
                     setOpacity: jasmine.createSpy("setOpacity"),
                     setVisible: jasmine.createSpy("setVisible"),
-                    _layer_type: "ImageStatic"
+                    _layer_type: "BingMaps"
                 };
                 widget.layers["LayerName"] = layer_mock;
 

--- a/tests/js/OpenlayersWidgetSpec.js
+++ b/tests/js/OpenlayersWidgetSpec.js
@@ -50,11 +50,11 @@
         });
     };
 
-    describe("ol3-map", function () {
+    describe("ol3-map", () => {
 
         var widget;
 
-        beforeAll(function () {
+        beforeAll(() => {
             window.MashupPlatform = new MockMP({
                 type: 'widget',
                 prefs: {
@@ -69,14 +69,14 @@
             });
         });
 
-        beforeEach(function () {
+        beforeEach(() => {
             clearDocument();
             document.body.innerHTML += HTML_FIXTURE;
             MashupPlatform.reset();
             widget = new Widget();
         });
 
-        afterEach(function () {
+        afterEach(() => {
             if (widget && widget.visiblePoisTimeout) {
                 clearTimeout(widget.visiblePoisTimeout);
             }
@@ -1287,7 +1287,7 @@
 
         });
 
-        describe("addLayer(options)", function () {
+        describe("addLayer(options)", () => {
 
             var mock_layers = function mock_layers(widget) {
                 var layers_mock = {
@@ -1307,7 +1307,7 @@
                 }).toThrowError(MashupPlatform.wiring.EndpointValueError);
             });
 
-            it("supports Image WMS layers", function () {
+            it("supports Image WMS layers", () => {
                 widget.init();
                 var layers_mock = mock_layers(widget);
 
@@ -1324,7 +1324,7 @@
                 expect(layers_mock.insertAt.calls.argsFor(0)[1].getSource()).toEqual(jasmine.any(ol.source.ImageWMS));
             });
 
-            it("supports Image WMS layers (provides a default params option)", function () {
+            it("supports Image WMS layers (provides a default params option)", () => {
                 widget.init();
                 var layers_mock = mock_layers(widget);
 
@@ -1338,7 +1338,7 @@
                 expect(layers_mock.insertAt.calls.argsFor(0)[1].getSource()).toEqual(jasmine.any(ol.source.ImageWMS));
             });
 
-            it("supports Image WMS layers (uses layer id as default LAYERS parameter)", function () {
+            it("supports Image WMS layers (uses layer id as default LAYERS parameter)", () => {
                 widget.init();
                 var layers_mock = mock_layers(widget);
 
@@ -1355,7 +1355,7 @@
                 expect(layers_mock.insertAt.calls.argsFor(0)[1].getSource()).toEqual(jasmine.any(ol.source.ImageWMS));
             });
 
-            it("supports ImageArcGISRest layers", function () {
+            it("supports ImageArcGISRest layers", () => {
                 widget.init();
                 var layers_mock = mock_layers(widget);
 
@@ -1369,7 +1369,7 @@
                 expect(layers_mock.insertAt.calls.argsFor(0)[1].getSource()).toEqual(jasmine.any(ol.source.ImageArcGISRest));
             });
 
-            it("supports ImageMapGuide layers", function () {
+            it("supports ImageMapGuide layers", () => {
                 widget.init();
                 var layers_mock = mock_layers(widget);
 
@@ -1383,7 +1383,7 @@
                 expect(layers_mock.insertAt.calls.argsFor(0)[1].getSource()).toEqual(jasmine.any(ol.source.ImageMapGuide));
             });
 
-            it("supports ImageStatic layers", function () {
+            it("supports ImageStatic layers", () => {
                 widget.init();
                 var layers_mock = mock_layers(widget);
 
@@ -1397,7 +1397,7 @@
                 expect(layers_mock.insertAt.calls.argsFor(0)[1].getSource()).toEqual(jasmine.any(ol.source.ImageStatic));
             });
 
-            it("supports Vector layers", function () {
+            it("supports Vector layers", () => {
                 widget.init();
                 var layers_mock = mock_layers(widget);
 
@@ -1412,7 +1412,7 @@
                 expect(layers_mock.insertAt.calls.argsFor(0)[1].getSource()).toEqual(jasmine.any(ol.source.Vector));
             });
 
-            it("raises an EndpointValueError exception when trying to create a Vector layer without providing the format", function () {
+            it("raises an EndpointValueError exception when trying to create a Vector layer without providing the format", () => {
                 widget.init();
                 var layers_mock = mock_layers(widget);
 
@@ -1425,7 +1425,7 @@
                 }).toThrowError(MashupPlatform.wiring.EndpointValueError);
             });
 
-            it("raises an EndpointValueError exception when trying to create a Vector layer without providing a layer url", function () {
+            it("raises an EndpointValueError exception when trying to create a Vector layer without providing a layer url", () => {
                 widget.init();
                 var layers_mock = mock_layers(widget);
 
@@ -1438,7 +1438,7 @@
                 }).toThrowError(MashupPlatform.wiring.EndpointValueError);
             });
 
-            it("supports Vector layers (with format options)", function () {
+            it("supports Vector layers (with format options)", () => {
                 widget.init();
                 var layers_mock = mock_layers(widget);
 
@@ -1456,7 +1456,7 @@
                 expect(layers_mock.insertAt.calls.argsFor(0)[1].getSource()).toEqual(jasmine.any(ol.source.Vector));
             });
 
-            it("supports Vector layers (with GML format options)", function () {
+            it("supports Vector layers (with GML format options)", () => {
                 widget.init();
                 var layers_mock = mock_layers(widget);
 
@@ -1475,7 +1475,7 @@
             });
 
 
-            it("supports VectorTile layers", function () {
+            it("supports VectorTile layers", () => {
                 widget.init();
                 var layers_mock = mock_layers(widget);
 
@@ -1494,7 +1494,7 @@
                 expect(layers_mock.insertAt.calls.argsFor(0)[1].getSource()).toEqual(jasmine.any(ol.source.VectorTile));
             });
 
-            it("supports OSM layers", function () {
+            it("supports OSM layers", () => {
                 widget.init();
                 var layers_mock = mock_layers(widget);
 
@@ -1507,7 +1507,7 @@
                 expect(layers_mock.insertAt.calls.argsFor(0)[1].getSource()).toEqual(jasmine.any(ol.source.OSM));
             });
 
-            it("supports Tile WMS layers", function () {
+            it("supports Tile WMS layers", () => {
                 widget.init();
                 var layers_mock = mock_layers(widget);
 
@@ -1526,7 +1526,7 @@
                 expect(layers_mock.insertAt.calls.argsFor(0)[1].getSource()).toEqual(jasmine.any(ol.source.TileWMS));
             });
 
-            it("supports Tile WMS layers (provides a default params option)", function () {
+            it("supports Tile WMS layers (provides a default params option)", () => {
                 widget.init();
                 var layers_mock = mock_layers(widget);
 
@@ -1541,7 +1541,7 @@
                 expect(layers_mock.insertAt.calls.argsFor(0)[1].getSource()).toEqual(jasmine.any(ol.source.TileWMS));
             });
 
-            it("supports Tile WMS layers (uses layer id as default LAYERS parameter)", function () {
+            it("supports Tile WMS layers (uses layer id as default LAYERS parameter)", () => {
                 widget.init();
                 var layers_mock = mock_layers(widget);
 
@@ -1559,7 +1559,7 @@
                 expect(layers_mock.insertAt.calls.argsFor(0)[1].getSource()).toEqual(jasmine.any(ol.source.TileWMS));
             });
 
-            it("supports Tile JSON layers", function () {
+            it("supports Tile JSON layers", () => {
                 widget.init();
                 var layers_mock = mock_layers(widget);
 
@@ -1574,7 +1574,7 @@
                 expect(layers_mock.insertAt.calls.argsFor(0)[1].getSource()).toEqual(jasmine.any(ol.source.TileJSON));
             });
 
-            it("supports Tile UTF Grid layers", function () {
+            it("supports Tile UTF Grid layers", () => {
                 widget.init();
                 var layers_mock = mock_layers(widget);
 
@@ -1588,7 +1588,7 @@
                 expect(layers_mock.insertAt.calls.argsFor(0)[1].getSource()).toEqual(jasmine.any(ol.source.TileUTFGrid));
             });
 
-            it("supports XYZ layers", function () {
+            it("supports XYZ layers", () => {
                 widget.init();
                 var layers_mock = mock_layers(widget);
 
@@ -1602,7 +1602,7 @@
                 expect(layers_mock.insertAt.calls.argsFor(0)[1].getSource()).toEqual(jasmine.any(ol.source.XYZ));
             });
 
-            it("supports Stamen layers", function () {
+            it("supports Stamen layers", () => {
                 widget.init();
                 var layers_mock = mock_layers(widget);
 
@@ -1616,7 +1616,7 @@
                 expect(layers_mock.insertAt.calls.argsFor(0)[1].getSource()).toEqual(jasmine.any(ol.source.Stamen));
             });
 
-            it("supports BingMaps layers", function () {
+            it("supports BingMaps layers", () => {
                 widget.init();
                 var layers_mock = mock_layers(widget);
 
@@ -1630,7 +1630,7 @@
                 expect(layers_mock.insertAt.calls.argsFor(0)[1].getSource()).toEqual(jasmine.any(ol.source.BingMaps));
             });
 
-            it("supports CartoDB layers", function () {
+            it("supports CartoDB layers", () => {
                 widget.init();
                 var layers_mock = mock_layers(widget);
 
@@ -1654,7 +1654,7 @@
                 expect(layers_mock.insertAt.calls.argsFor(0)[1].getSource()).toEqual(jasmine.any(ol.source.CartoDB));
             });
 
-            it("supports WMTS layers", function () {
+            it("supports WMTS layers", () => {
                 widget.init();
                 var layers_mock = mock_layers(widget);
 
@@ -1668,7 +1668,7 @@
                 expect(layers_mock.insertAt.calls.argsFor(0)[1].getSource()).toEqual(jasmine.any(ol.source.WMTS));
             });
 
-            it("supports Zoomify layers", function () {
+            it("supports Zoomify layers", () => {
                 widget.init();
                 var layers_mock = mock_layers(widget);
 
@@ -1683,7 +1683,7 @@
                 expect(layers_mock.insertAt.calls.argsFor(0)[1].getSource()).toEqual(jasmine.any(ol.source.Zoomify));
             });
 
-            it("replaces layers with the same id", function () {
+            it("replaces layers with the same id", () => {
                 widget.init();
                 var layers_mock = mock_layers(widget);
                 spyOn(widget.map, 'removeLayer');


### PR DESCRIPTION
Allow to configure some additional options when creating layers. In particular, this PR adds support for the following general options:

- `opacity` layer opacity
- `visible` layer visibility
- `viewMaxZoom` maximum zoom level at which this layer will be visible (So this option maps with the `maxZoom` option provided by Open Layers on the layer class, while the `maxZoom` option is mapped to the `maxZoom` option on the source)
- `viewMinZoom` minimum zoom level at which this layer will be visible (So this option maps with the `minZoom` option provided by Open Layers on the layer class, while the `minZoom` option is mapped to the `minZoom` option on the source)

In addition to this, the coordinates sent using the `extent` option are now translated from `EPSG:4326` into map coordinates. 

Finally, this PR also adds support for updating the `visible` and `opacity` options on any layer, and the `url` option on the following layer types:
- `ImageArcGISRest`
- `ImageMapGuide`
- `ImageStatic`
- `ImageWMS`
- `Stamen`
- `TileJSON`
- `TileUTFGrid`
- `TileWMS`
- `Vector`
- `VectorTile`
- `WMTS`
- `XYZ`
- `Zoomify`