### PR TITLE
Add custom style option with image or text

### DIFF
--- a/src/config.xml
+++ b/src/config.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<widget xmlns="http://wirecloud.conwet.fi.upm.es/ns/macdescription/1" vendor="CoNWeT" name="ol3-map" version="1.2.1">
+<widget xmlns="http://wirecloud.conwet.fi.upm.es/ns/macdescription/1" vendor="CoNWeT" name="ol3-map" version="1.2.2a1">
     <details>
         <title>OpenLayers Map</title>
         <email>wirecloud@conwet.com</email>

--- a/src/doc/changelog.md
+++ b/src/doc/changelog.md
@@ -1,3 +1,7 @@
+## v1.2.2 (2020-XX-XX)
+
+- Add custom style option with image or text
+
 ## v1.2.1 (2020-03-07)
 
 - Use OSM layer by default. Previous versions of the widget were using Wikimedia

--- a/src/js/ol3-map-widget.js
+++ b/src/js/ol3-map-widget.js
@@ -148,7 +148,16 @@
             })
         });
 
+        if (options.style.text != null) {
+            style.setText(options.style.text(ol, options.style));
+        }
+
         return (feature, resolution) => {
+            var data = feature.get('data');
+            if (data.style != null && data.style.context != null) {
+                data.style.context(ol, style, feature, resolution);
+            }
+
             if (this.selected_feature === feature) {
                 return style;
             }
@@ -207,6 +216,8 @@
                 src: icon.src,
                 scale: icon.scale
             }));
+        } else if (vector_style != null && vector_style.image != null) {
+            var image = vector_style.image(ol, vector_style, this.map.getView().getResolution());
         }
         let marker_style = build_basic_style.call(this, {
             image: image,

--- a/tests/js/OpenlayersWidgetSpec.js
+++ b/tests/js/OpenlayersWidgetSpec.js
@@ -966,6 +966,119 @@
 
             });
 
+            describe("handles the custom styles:", () => {
+                it("Add custom style image", () => {
+                    widget.init();
+                    spyOn(widget.vector_source, 'addFeature');
+                    widget.registerPoI(deepFreeze({
+                        id: '1',
+                        data: {},
+                        location: {
+                            type: 'Point',
+                            coordinates: [0, 0]
+                        },
+                        style: {
+                            image: function (ol, style, resolution) {
+                                return new ol.style.Circle({
+                                    fill: new ol.style.Fill({
+                                        color: '#111111'
+                                    }),
+                                    radius: (1000 / resolution) * style.radius,
+                                    stroke: new ol.style.Stroke({
+                                        color: '#222222',
+                                        width: 1
+                                    })
+                                });
+                            },
+                            radius: 10,
+                        },
+                    }));
+                    expect(widget.vector_source.addFeature).toHaveBeenCalledTimes(1);
+                    expect(widget.vector_source.addFeature).toHaveBeenCalledWith(jasmine.any(ol.Feature));
+                    let feature = widget.vector_source.addFeature.calls.argsFor(0)[0];
+                    let fstyle = feature.getStyle()(feature);
+                    expect(fstyle.getImage().getFill().getColor()).toEqual('#111111');
+                    expect(fstyle.getImage().getRadius()).toEqual(65.41332273339661);
+                    expect(fstyle.getImage().getStroke().getColor()).toEqual('#222222');
+                    expect(fstyle.getImage().getStroke().getWidth()).toEqual(1);
+                });
+
+                it("Add custom style text", () => {
+                    widget.init();
+                    spyOn(widget.vector_source, 'addFeature');
+                    widget.registerPoI(deepFreeze({
+                        id: '1',
+                        data: {},
+                        location: {
+                            type: 'Point',
+                            coordinates: [0, 0]
+                        },
+                        style: {
+                            text: function (ol, style) {
+                                return new ol.style.Text({
+                                    font: '12px serif',
+                                    text: style.value.toString(),
+                                    fill: new ol.style.Fill({
+                                        color: '#333333'
+                                    })
+                                })
+                            },
+                            value: 'test',
+                        },
+                    }));
+                    expect(widget.vector_source.addFeature).toHaveBeenCalledTimes(1);
+                    expect(widget.vector_source.addFeature).toHaveBeenCalledWith(jasmine.any(ol.Feature));
+                    let feature = widget.vector_source.addFeature.calls.argsFor(0)[0];
+                    let fstyle = feature.getStyle()(feature);
+                    expect(fstyle.getText().getFont()).toEqual('12px serif');
+                    expect(fstyle.getText().getText()).toEqual('test');
+                    expect(fstyle.getText().getFill().getColor()).toEqual('#333333');
+                });
+
+                it("Add custom style image with maxzoom", () => {
+                    widget.init();
+                    spyOn(widget.vector_source, 'addFeature');
+                    widget.registerPoI(deepFreeze({
+                        id: '1',
+                        data: {},
+                        location: {
+                            type: 'Point',
+                            coordinates: [0, 0]
+                        },
+                        maxzoom: 13,
+                        style: {
+                            image: function (ol, style, resolution) {
+                                return new ol.style.Circle({
+                                    fill: new ol.style.Fill({
+                                        color: '#444444'
+                                    }),
+                                    radius: (1000 / resolution) * style.radius,
+                                    stroke: new ol.style.Stroke({
+                                        color: '#555555',
+                                        width: 2
+                                    })
+                                });
+                            },
+                            radius: 10,
+                            context: function (ol, style, feature, resolution) {
+                                style.getImage().setRadius(20);
+                            },
+                        },
+                    }));
+
+                    expect(widget.vector_source.addFeature).toHaveBeenCalledTimes(1);
+                    expect(widget.vector_source.addFeature).toHaveBeenCalledWith(jasmine.any(ol.Feature));
+                    let feature = widget.vector_source.addFeature.calls.argsFor(0)[0];
+                    let fstyle = feature.getStyle()(feature);
+                    expect(fstyle.getImage().getFill().getColor()).toEqual('#444444');
+                    expect(fstyle.getImage().getRadius()).toEqual(20);
+                    expect(fstyle.getImage().getStroke().getColor()).toEqual('#555555');
+                    expect(fstyle.getImage().getStroke().getWidth()).toEqual(2);
+
+                });
+
+            });
+
             describe("handles the minzoom option:", () => {
                 const test = function (resolution, displayed) {
                     return () => {


### PR DESCRIPTION
Hi @aarranz,

How are you?  I'd like to add new feature to this widget. It would be great if you could review this PR.

The PR adds a feature for creating a custom marker style with image or text. This allows you to draw PoIs with a style as circle or text on a map. The feature is enabled when receiving a entity with a style that has the `image`, `context` and `text` attributes as shown:

```
style: {
    image: function (ol, style, resolution) {
        return new ol.style.Circle({
            fill: new ol.style.Fill({
                color: 'rgba(255, 252, 76, 0.5)'
            }),
            radius: (1000 / resolution) * style.radius,
            stroke: new ol.style.Stroke({
                color: 'rgba(255, 252, 76, 1)',
                width: 1
            })
        });
    },
    radius: 1000,
    context: function (ol, style, feature, resolution) {
        var radius = feature.get('data').style.radius;
        radius = (1000 / resolution) * radius;
        style.getImage().setRadius(radius);
    },
    text: function (ol, style) {
        return new ol.style.Text({
            font: '12px serif',
            text: style.value,
            fill: new ol.style.Fill({
                color: '#00008B'
            })
        });
    },
    value: 'test'
}
```

-   The `image` attribute is  specified a function that returns an ol.style.Circle object.
-   The `context` attribute is specified a function that is called when zooming.
-   The `text` attribute is specified a function that returns an ol.style.Text object.

## Use Case

For instance, this feature allows you to create a bubble map as shown:

![png1](https://user-images.githubusercontent.com/31051904/82110032-28859680-9776-11ea-9de6-79594e0e9ec6.png)

### How to setup

1. You do wiring [the Json injector](https://github.com/lets-fiware/json-injector/releases/download/v0.1.5/FISUDA_json-injector_0.1.5.wgt), [the ol3 bubble map](https://github.com/lets-fiware/ol3-bubble-map-operator/releases/download/v0.1.0/FISUDA_ol3-bubble-map_0.1.0.wgt) and this OpenLayers Map widget  as shown:

-    https://github.com/lets-fiware/json-injector
-    https://github.com/lets-fiware/ol3-bubble-map-operator

![png2](https://user-images.githubusercontent.com/31051904/82110037-2e7b7780-9776-11ea-810c-b54d942c3058.png)

2. You send a following json data with the Json injector. A circle centered on Madrid will be drawn on a map.

```
[
  {
    "id": "place001",
    "type": "PointOfInterest",
    "name": "Madrid",
    "location": {
      "type": "Point",
      "coordinates": [-3.703,40.417]
    },
    "radius": 1000
  }
]
```
## Live Demo
![covid19-world-map](https://user-images.githubusercontent.com/31051904/82109993-ec523600-9775-11ea-9098-d5e0dd577526.png)

- [https://mashup.lab.fisuda.jp/letsfiware/covid19-world-map#view=workspace&tab=%E3%82%BF%E3%83%96](https://mashup.lab.fisuda.jp/letsfiware/covid19-world-map#view=workspace&tab=%E3%82%BF%E3%83%96)

Thanks!