### PR TITLE
Use PoI id for the selection popup menu if the PoI does not provide a title attribute

### DIFF
--- a/src/config.xml
+++ b/src/config.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<widget xmlns="http://wirecloud.conwet.fi.upm.es/ns/macdescription/1" vendor="CoNWeT" name="ol3-map" version="1.2.1">
+<widget xmlns="http://wirecloud.conwet.fi.upm.es/ns/macdescription/1" vendor="CoNWeT" name="ol3-map" version="1.2.2b1">
     <details>
         <title>OpenLayers Map</title>
         <email>wirecloud@conwet.com</email>

--- a/src/doc/changelog.md
+++ b/src/doc/changelog.md
@@ -1,3 +1,9 @@
+## v1.2.2 (2021-03-XX)
+
+- Use PoI id for the selection popup menu if the PoI does not provide a title
+    attribute.
+
+
 ## v1.2.1 (2020-03-07)
 
 - Use OSM layer by default. Previous versions of the widget were using Wikimedia

--- a/src/js/ol3-map-widget.js
+++ b/src/js/ol3-map-widget.js
@@ -361,7 +361,7 @@
                 } else {
                     var popup_menu = new StyledElements.PopupMenu();
                     features.forEach((feature) => {
-                        popup_menu.append(new StyledElements.MenuItem(feature.get('title'), null, feature));
+                        popup_menu.append(new StyledElements.MenuItem(feature.get('title') || feature.getId(), null, feature));
                     });
                     popup_menu.addEventListener("click", (menu, item) => {
                         this.select_feature(item.context);


### PR DESCRIPTION
Currently, the `title` parameter is optional in the PoI payloads but the widget is creating the selection list using this parameter. So, if you click in an area where some marker does not provide such parameter you get a blank list like this:

<img width="407" alt="Captura de pantalla 2021-03-23 a las 13 05 39" src="https://user-images.githubusercontent.com/841201/112144056-fb491680-8bd8-11eb-9b7d-38362ee51f35.png">

This PR fixes this problem by making the widget to use the id in such case where the PoI information does not contains a title parameter.