### PR TITLE
Switch code to use let and const

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -115,6 +115,15 @@
     "curly": [
       2,
       "all"
+    ],
+    "prefer-const": [
+      "error"
+    ],
+    "no-var": [
+      "error"
+    ],
+    "no-const-assign": [
+      "error"
     ]
   }
 }

--- a/.eslintrc-jasmine
+++ b/.eslintrc-jasmine
@@ -115,6 +115,15 @@
     "curly": [
       2,
       "all"
+    ],
+    "prefer-const": [
+      "error"
+    ],
+    "no-var": [
+      "error"
+    ],
+    "no-const-assign": [
+      "error"
     ]
   }
 }

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -14,8 +14,8 @@
  *   limitations under the License.
  */
 
-var ConfigParser = require('wirecloud-config-parser');
-var parser = new ConfigParser('src/config.xml');
+const ConfigParser = require('wirecloud-config-parser');
+const parser = new ConfigParser('src/config.xml');
 
 module.exports = function (grunt) {
 
@@ -40,7 +40,7 @@ module.exports = function (grunt) {
                 options: {
                     configFile: '.eslintrc-jasmine'
                 },
-                src: ['src/test/**/*.js', '!src/test/fixtures/']
+                src: ['tests/**/*Spec.js', '!tests/fixtures/']
             }
         },
 

--- a/src/doc/changelog.md
+++ b/src/doc/changelog.md
@@ -6,6 +6,7 @@
   events).
 - Repaint popovers when moving/zooming the map (when using sticky events).
 - Fix placement of popovers when icon anchor is different to `[0.5, 1]`
+- Switch code to use let and const
 
 
 ## v1.2.3 (2021-03-25)

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -21,7 +21,7 @@
 
     "use strict";
 
-    var parseInputEndpointData = function parseInputEndpointData(data) {
+    const parseInputEndpointData = function parseInputEndpointData(data) {
         if (typeof data === "string") {
             try {
                 data = JSON.parse(data);
@@ -34,7 +34,7 @@
         return data;
     };
 
-    var widget = new Widget('body', '#incoming-modal');
+    const widget = new Widget('body', '#incoming-modal');
     widget.init();
 
     MashupPlatform.prefs.registerCallback((new_values) => {

--- a/src/js/ol3-map-widget.js
+++ b/src/js/ol3-map-widget.js
@@ -21,13 +21,13 @@
 
     "use strict";
 
-    var internalUrl = function internalUrl(data) {
-        var url = document.createElement("a");
+    const internalUrl = function internalUrl(data) {
+        const url = document.createElement("a");
         url.setAttribute('href', data);
         return url.href;
     };
 
-    var CORE_LAYERS = {
+    const CORE_LAYERS = {
         WIKIMEDIA: new ol.layer.Tile({
             source: new ol.source.OSM({
                 url: "https://maps.wikimedia.org/osm-intl/{z}/{x}/{y}.png"
@@ -94,7 +94,28 @@
     CORE_LAYERS.GOOGLE_HYBRID = CORE_LAYERS.MAPQUEST_HYBRID;
     CORE_LAYERS.GOOGLE_SATELLITE = CORE_LAYERS.MAPQUEST_SATELLITE;
 
-    var build_basic_style = function build_basic_style(options) {
+    const update_selected_feature = function update_selected_feature(feature) {
+        if (this.selected_feature != feature) {
+            this.selected_feature = feature;
+            if (this.popover != null) {
+                this.popover.hide();
+                this.popover = null;
+            }
+            MashupPlatform.widget.outputs.poiOutput.pushEvent(feature != null ? feature.get('data') : null);
+        }
+    };
+
+    const unselect = function unselect(feature) {
+        if (feature == null) {
+            return;
+        }
+
+        const poi_info = feature.get('data');
+        const style = parse_marker_definition.call(this, poi_info.icon, poi_info.style);
+        feature.setStyle(style);
+    };
+
+    const build_basic_style = function build_basic_style(options) {
         if (options == null) {
             options = {};
         }
@@ -137,7 +158,7 @@
             };
         }
 
-        let style = new ol.style.Style({
+        const style = new ol.style.Style({
             image: options.image,
             stroke: new ol.style.Stroke({
                 color: stroke.color,
@@ -153,8 +174,8 @@
                 return style;
             }
 
-            var minzoom = feature.get('minzoom');
-            var maxzoom = feature.get('maxzoom');
+            const minzoom = feature.get('minzoom');
+            const maxzoom = feature.get('maxzoom');
 
             if (minzoom != null && resolution > minzoom) {
                 return null;
@@ -166,7 +187,7 @@
         };
     };
 
-    var parse_marker_definition = function parse_marker_definition(icon, vector_style) {
+    const parse_marker_definition = function parse_marker_definition(icon, vector_style) {
         let clone = false;
         if (icon == null && vector_style == null) {
             return DEFAULT_MARKER;
@@ -198,8 +219,9 @@
             icon.scale = 1;
         }
 
+        let image;
         if (icon.src != null) {
-            var image = new ol.style.Icon(/** @type {olx.style.IconOptions} */ ({
+            image = new ol.style.Icon(/** @type {olx.style.IconOptions} */ ({
                 anchor: icon.anchor,
                 anchorXUnits: icon.anchorXUnits,
                 anchorYUnits: icon.anchorYUnits,
@@ -215,7 +237,7 @@
             if (canvas == null) {
                 return DEFAULT_MARKER;
             }
-            var image = new ol.style.Icon(/** @type {olx.style.IconOptions} */ ({
+            image = new ol.style.Icon(/** @type {olx.style.IconOptions} */ ({
                 anchor: icon.anchor,
                 anchorXUnits: icon.anchorXUnits,
                 anchorYUnits: icon.anchorYUnits,
@@ -224,7 +246,7 @@
                 imgSize: [canvas.width, canvas.height]
             }));
         }
-        let marker_style = build_basic_style.call(this, {
+        const marker_style = build_basic_style.call(this, {
             image: image,
             style: vector_style
         });
@@ -256,7 +278,7 @@
         }
 
         this.fa_marker_cache = {};
-    }
+    };
 
     // Build a marker with Font awsome icon
     const build_font_awesome_icon = function build_font_awesome_icon(fontSymbol) {
@@ -264,7 +286,7 @@
             create_fa_glyph_table.call(this);
         }
         const glyph = fontSymbol.glyph || 'fa-star';
-        let form = fontSymbol.form || 'marker';
+        const form = fontSymbol.form || 'marker';
         const size = fontSymbol.size || 16;
         const fill = fontSymbol.fill || 'blue';
         const stroke = fontSymbol.stroke || 'white';
@@ -343,9 +365,9 @@
 
         this.fa_marker_cache[hash] = canvas;
         return this.fa_marker_cache[hash];
-    }
+    };
 
-    var send_visible_pois = function send_visible_pois() {
+    const send_visible_pois = function send_visible_pois() {
 
         if (this.visiblePoisTimeout != null) {
             clearTimeout(this.visiblePoisTimeout);
@@ -356,17 +378,17 @@
             return;
         }
 
-        var extent = this.map.getView().calculateExtent(this.map.getSize());
-        var data = this.vector_source.getFeaturesInExtent(extent).map((feature) => {
+        const extent = this.map.getView().calculateExtent(this.map.getSize());
+        const data = this.vector_source.getFeaturesInExtent(extent).map((feature) => {
             return feature.get('data');
         });
         MashupPlatform.widget.outputs.poiListOutput.pushEvent(data);
     };
 
     // Create the default Marker style
-    var DEFAULT_MARKER = null;
+    let DEFAULT_MARKER = null;
 
-    var Widget = function Widget() {
+    const Widget = function Widget() {
         this.selected_feature = null;
         this.layers_widget = null;
         this.base_layer = null;
@@ -376,7 +398,7 @@
 
     Widget.prototype.init = function init() {
 
-        let layers_button = document.getElementById('button');
+        const layers_button = document.getElementById('button');
         layers_button.addEventListener('click', (event) => {
             if (this.layers_widget == null) {
                 this.layers_widget = MashupPlatform.mashup.addWidget(MashupPlatform.prefs.get('layerswidget').trim(), {refposition: event.target.getBoundingClientRect()});
@@ -384,7 +406,7 @@
                 this.layers_widget.outputs.layerInfoOutput.connect(MashupPlatform.widget.inputs.layerInfo);
             }
         });
-        let layers_widget_ref = MashupPlatform.prefs.get('layerswidget').trim();
+        const layers_widget_ref = MashupPlatform.prefs.get('layerswidget').trim();
         if (layers_widget_ref === "") {
             layers_button.classList.remove('in');
         } else {
@@ -435,7 +457,7 @@
 
         DEFAULT_MARKER = build_basic_style.call(this);
         this.base_layer = CORE_LAYERS.OSM;
-        var initialCenter = MashupPlatform.prefs.get("initialCenter").split(",").map(Number);
+        let initialCenter = MashupPlatform.prefs.get("initialCenter").split(",").map(Number);
         if (initialCenter.length != 2 || !Number.isFinite(initialCenter[0]) || !Number.isFinite(initialCenter[1])) {
             initialCenter = [0, 0];
         }
@@ -449,17 +471,17 @@
             source: this.vector_source
         });
         this.marker_cache = {};
-        var styleCache = {};
+        const styleCache = {};
         this.vector_layer = new ol.layer.Vector({source: this.vector_source, style: DEFAULT_MARKER});
         this.cluster_layer = new ol.layer.Vector({
             source: this.cluster_source,
             style: function (feature, resolution) {
-                var features = feature.get('features');
-                var size = features.length;
+                const features = feature.get('features');
+                const size = features.length;
                 if (size === 1) {
                     return features[0].getStyle()(features[0], resolution);
                 }
-                var style = styleCache[size];
+                let style = styleCache[size];
                 if (!style) {
                     style = new ol.style.Style({
                         image: new ol.style.Circle({
@@ -498,7 +520,7 @@
 
         // display popup on click
         this.map.on('click', function (event) {
-            var features = [];
+            const features = [];
             this.map.forEachFeatureAtPixel(
                 event.pixel,
                 MashupPlatform.prefs.get('useclustering') ?
@@ -526,7 +548,7 @@
                     unselect.call(this, this.selected_feature);
                     update_selected_feature.call(this, null);
                 } else {
-                    var popup_menu = new StyledElements.PopupMenu();
+                    const popup_menu = new StyledElements.PopupMenu();
                     features.forEach((feature) => {
                         popup_menu.append(new StyledElements.MenuItem(feature.get('title') || feature.getId(), null, feature));
                     });
@@ -546,7 +568,7 @@
                 return;
             }
 
-            var feature = features[0];
+            const feature = features[0];
 
             if (feature != null && feature !== this.selected_feature) {
                 this.select_feature(feature);
@@ -567,8 +589,8 @@
                 }
                 return;
             }
-            var pixel = this.map.getEventPixel(event.originalEvent);
-            var hit = this.map.hasFeatureAtPixel(pixel);
+            const pixel = this.map.getEventPixel(event.originalEvent);
+            const hit = this.map.hasFeatureAtPixel(pixel);
             this.map.getTarget().style.cursor = hit ? 'pointer' : '';
         });
 
@@ -607,7 +629,7 @@
     };
 
     Widget.prototype.registerPoI = function registerPoI(poi_info) {
-        var iconFeature, style, geometry, marker, minzoom, maxzoom;
+        let iconFeature, style, geometry, marker;
 
         if ('location' in poi_info) {
             geometry = this.geojsonparser.readGeometry(poi_info.location).transform('EPSG:4326', 'EPSG:3857');
@@ -630,8 +652,8 @@
         }
 
         iconFeature = this.vector_source.getFeatureById(poi_info.id);
-        minzoom = poi_info.minzoom != null ? this.map.getView().getResolutionForZoom(poi_info.minzoom) : null;
-        maxzoom = poi_info.maxzoom != null ? this.map.getView().getResolutionForZoom(poi_info.maxzoom) : null;
+        const minzoom = poi_info.minzoom != null ? this.map.getView().getResolutionForZoom(poi_info.minzoom) : null;
+        const maxzoom = poi_info.maxzoom != null ? this.map.getView().getResolutionForZoom(poi_info.maxzoom) : null;
         if (iconFeature == null) {
             iconFeature = new ol.Feature({
                 geometry: geometry,
@@ -684,7 +706,7 @@
             if (this.popover != null) {
                 this.popover.hide();
             }
-            let new_selected_feature = this.vector_source.getFeatureById(this.selected_feature.getId());
+            const new_selected_feature = this.vector_source.getFeatureById(this.selected_feature.getId());
             if (new_selected_feature != null) {
                 this.select_feature(new_selected_feature);
             }
@@ -703,31 +725,31 @@
             return update_selected_feature.call(this, null);
         }
 
-        let geometry = new ol.geom.GeometryCollection(poi_info.map((poi) => {
-            var feature = this.vector_source.getFeatureById(poi.id);
+        const geometry = new ol.geom.GeometryCollection(poi_info.map((poi) => {
+            const feature = this.vector_source.getFeatureById(poi.id);
             return feature.getGeometry();
         }));
 
         // Update map view
-        let zoom = parseInt(MashupPlatform.prefs.get('poiZoom'), 10);
-        let currentZoom = this.map.getView().getZoom();
+        const zoom = parseInt(MashupPlatform.prefs.get('poiZoom'), 10);
+        const currentZoom = this.map.getView().getZoom();
         if (currentZoom < zoom) {
             this.map.getView().fit(geometry.getExtent(), {
                 maxZoom: zoom
             });
         } else {
-            let view_extent = this.map.getView().calculateExtent(this.map.getSize());
-            let geometry_extent = geometry.getExtent();
+            const view_extent = this.map.getView().calculateExtent(this.map.getSize());
+            const geometry_extent = geometry.getExtent();
             if (!ol.extent.containsExtent(view_extent, geometry_extent)) {
-                let view_size = ol.extent.getSize(view_extent);
-                let geometry_size = ol.extent.getSize(geometry_extent);
+                const view_size = ol.extent.getSize(view_extent);
+                const geometry_size = ol.extent.getSize(geometry_extent);
 
                 if (view_size[0] < geometry_size[0] && view_size[1] < geometry_size[1]) {
                     this.map.getView().fit(geometry.getExtent(), {
                         maxZoom: zoom
                     });
                 } else {
-                    let center = ol.extent.getCenter(geometry_extent);
+                    const center = ol.extent.getCenter(geometry_extent);
                     this.map.getView().setCenter(center);
                 }
             }
@@ -738,7 +760,7 @@
         }
     };
 
-    var format_builders = {
+    const format_builders = {
         "EsriJSON": ol.format.EsriJSON,
         "GeoJSON": ol.format.GeoJSON,
         "GML": ol.format.GML,
@@ -756,7 +778,7 @@
         "WMSGetFeatureInfo": ol.format.WMSGetFeatureInfo,
     }
 
-    var addFormat = function addFormat(layer_info) {
+    const addFormat = function addFormat(layer_info) {
         if (layer_info.format == null) {
             throw new MashupPlatform.wiring.EndpointValueError("format option is required");
         }
@@ -775,7 +797,7 @@
     }
 
     Widget.prototype.addLayer = function addLayer(layer_info) {
-        var builder = layer_builders[layer_info.type];
+        const builder = layer_builders[layer_info.type];
         if (builder == null) {
             throw new MashupPlatform.wiring.EndpointValueError("Invalid layer type: " + layer_info.type);
         }
@@ -783,21 +805,21 @@
         // Remove any layer with the same id
         this.removeLayer(layer_info);
 
-        var layer = builder.call(this, layer_info);
+        const layer = builder.call(this, layer_info);
         layer._layer_type = layer_info.type;
-        var layers = this.map.getLayers();
+        const layers = this.map.getLayers();
         layers.insertAt(layers.getLength() - 1, layer);
 
         this.layers[layer_info.id] = layer;
     };
 
     Widget.prototype.updateLayer = function updateLayer(layer_info) {
-        var layer = this.layers[layer_info.id];
+        const layer = this.layers[layer_info.id];
         if (layer == null) {
             throw new MashupPlatform.wiring.EndpointValueError("Layer not found: " + layer_info.id);
         }
 
-        var updater = layer_updaters[layer._layer_type];
+        const updater = layer_updaters[layer._layer_type];
         if (updater != null) {
             updater(layer, layer_info);
         }
@@ -812,14 +834,14 @@
         }
     };
 
-    var build_compatible_url = function build_compatible_url(url, required) {
+    const build_compatible_url = function build_compatible_url(url, required) {
         if (required != true && url == null) {
             return undefined;
         } else if (required == true && url == null) {
             throw new MashupPlatform.wiring.EndpointValueError("Missing layer url option");
         }
 
-        var parsed_url = new URL(url);
+        const parsed_url = new URL(url);
         /* istanbul ignore if */
         if (document.location.protocol === 'https:' && parsed_url.protocol !== 'https:') {
             return MashupPlatform.http.buildProxyURL(parsed_url);
@@ -845,7 +867,7 @@
     };
 
     const addImageWMSLayer = function addImageWMSLayer(layer_info) {
-        var params = layer_info.params;
+        let params = layer_info.params;
 
         if (params == null) {
             params = {
@@ -871,7 +893,7 @@
         return build_layer.call(this, "Image", options, layer_info);
     };
 
-    var addImageArcGISRestLayer = function addImageArcGISRestLayer(layer_info) {
+    const addImageArcGISRestLayer = function addImageArcGISRestLayer(layer_info) {
         const options = {
             source: new ol.source.ImageArcGISRest({
                 url: build_compatible_url(layer_info.url, true),
@@ -886,7 +908,7 @@
         return build_layer.call(this, "Image", options, layer_info);
     };
 
-    var addImageMapGuideLayer = function addImageMapGuideLayer(layer_info) {
+    const addImageMapGuideLayer = function addImageMapGuideLayer(layer_info) {
         const options = {
             source: new ol.source.ImageMapGuide({
                 url: build_compatible_url(layer_info.url, true),
@@ -901,7 +923,7 @@
         return build_layer.call(this, "Image", options, layer_info);
     };
 
-    var addImageStaticLayer = function addImageStaticLayer(layer_info) {
+    const addImageStaticLayer = function addImageStaticLayer(layer_info) {
         const options = {
             source: new ol.source.ImageStatic({
                 url: build_compatible_url(layer_info.url, true),
@@ -915,7 +937,7 @@
         return build_layer.call(this, "Image", options, layer_info);
     };
 
-    var addVectorLayer = function addVectorLayer(layer_info) {
+    const addVectorLayer = function addVectorLayer(layer_info) {
         const options = {
             source: new ol.source.Vector({
                 crossOrigin: layer_info.crossOrigin,
@@ -937,7 +959,7 @@
         return build_layer.call(this, "Vector", options, layer_info);
     };
 
-    var addVectorTileLayer = function addVectorTileLayer(layer_info) {
+    const addVectorTileLayer = function addVectorTileLayer(layer_info) {
         const options = {
             source: new ol.source.VectorTile({
                 cacheSize: layer_info.cacheSize,
@@ -956,7 +978,7 @@
         return build_layer.call(this, "Tile", options, layer_info);
     };
 
-    var addOSMLayer = function addOSMLayer(layer_info) {
+    const addOSMLayer = function addOSMLayer(layer_info) {
         const options = {
             opacity: layer_info.opacity,
             source: new ol.source.OSM({
@@ -972,8 +994,8 @@
         return build_layer.call(this, "Tile", options, layer_info);
     };
 
-    var addTileWMSLayer = function addTileWMSLayer(layer_info) {
-        var params = layer_info.params;
+    const addTileWMSLayer = function addTileWMSLayer(layer_info) {
+        let params = layer_info.params;
 
         if (params == null) {
             params = {
@@ -999,7 +1021,7 @@
         return build_layer.call(this, "Tile", options, layer_info);
     };
 
-    var addTileJSONLayer = function addTileJSONLayer(layer_info) {
+    const addTileJSONLayer = function addTileJSONLayer(layer_info) {
         const options = {
             source: new ol.source.TileJSON({
                 cacheSize: layer_info.cacheSize,
@@ -1015,7 +1037,7 @@
         return build_layer.call(this, "Tile", options, layer_info);
     };
 
-    var addTileUTFGridLayer = function addTileUTFGridLayer(layer_info) {
+    const addTileUTFGridLayer = function addTileUTFGridLayer(layer_info) {
         const options = {
             source: new ol.source.UTFGrid({
                 jsonp: layer_info.jsonp,
@@ -1028,7 +1050,7 @@
         return build_layer.call(this, "Tile", options, layer_info);
     };
 
-    var addXYZLayer = function addXYZLayer(layer_info) {
+    const addXYZLayer = function addXYZLayer(layer_info) {
         const options = {
             preload: layer_info.preload,
             source: new ol.source.XYZ({
@@ -1047,7 +1069,7 @@
         return build_layer.call(this, "Tile", options, layer_info);
     };
 
-    var addStamenLayer = function addStamenLayer(layer_info) {
+    const addStamenLayer = function addStamenLayer(layer_info) {
         const options = {
             source: new ol.source.Stamen({
                 layer: layer_info.layer,
@@ -1078,7 +1100,7 @@
         return build_layer.call(this, "Tile", options, layer_info);
     };
 
-    var addCartoDBLayer = function addCartoDBLayer(layer_info) {
+    const addCartoDBLayer = function addCartoDBLayer(layer_info) {
         const options = {
             source: new ol.source.CartoDB({
                 account: layer_info.account,
@@ -1098,7 +1120,7 @@
         return build_layer.call(this, "Tile", options, layer_info);
     };
 
-    var addWMTSLayer = function addWMTSLayer(layer_info) {
+    const addWMTSLayer = function addWMTSLayer(layer_info) {
         const options = {
             source: new ol.source.WMTS({
                 cacheSize: layer_info.cacheSize,
@@ -1121,7 +1143,7 @@
         return build_layer.call(this, "Tile", options, layer_info);
     };
 
-    var addZoomifyLayer = function addZoomifyLayer(layer_info) {
+    const addZoomifyLayer = function addZoomifyLayer(layer_info) {
         const options = {
             source: new ol.source.Zoomify({
                 cacheSize: layer_info.cacheSize,
@@ -1137,7 +1159,7 @@
         return build_layer.call(this, "Tile", options, layer_info);
     };
 
-    var updateURL = function updateURL(layer, layer_info) {
+    const updateURL = function updateURL(layer, layer_info) {
         const source = layer.getSource();
         if ("url" in layer_info) {
             source.setUrl(layer_info.url);
@@ -1145,7 +1167,7 @@
     };
 
     Widget.prototype.removeLayer = function removeLayer(layer_info) {
-        var layer_id = layer_info.id;
+        const layer_id = layer_info.id;
         if (layer_id in this.layers) {
             this.map.removeLayer(this.layers[layer_id]);
             delete this.layers[layer_id];
@@ -1167,40 +1189,19 @@
         this.map.getLayers().insertAt(1, enabled ? this.cluster_layer : this.vector_layer);
     };
 
-    var update_selected_feature = function update_selected_feature(feature) {
-        if (this.selected_feature != feature) {
-            this.selected_feature = feature;
-            if (this.popover != null) {
-                this.popover.hide();
-                this.popover = null;
-            }
-            MashupPlatform.widget.outputs.poiOutput.pushEvent(feature != null ? feature.get('data') : null);
-        }
-    };
-
-    var unselect = function unselect(feature) {
-        if (feature == null) {
-            return;
-        }
-
-        var poi_info = feature.get('data');
-        var style = parse_marker_definition.call(this, poi_info.icon, poi_info.style);
-        feature.setStyle(style);
-    };
-
     Widget.prototype.select_feature = function select_feature(feature) {
 
         unselect.call(this, this.selected_feature);
 
-        var poi_info = feature.get('data');
-        var style = parse_marker_definition.call(this, poi_info.iconHighlighted || poi_info.icon, poi_info.styleHighlighted || poi_info.style);
+        const poi_info = feature.get('data');
+        const style = parse_marker_definition.call(this, poi_info.iconHighlighted || poi_info.icon, poi_info.styleHighlighted || poi_info.style);
         feature.setStyle(style);
 
         update_selected_feature.call(this, feature);
 
         if (feature.get('content') != null) {
             // The feature has content to be used on a popover
-            let popover = this.popover = new StyledElements.Popover({
+            const popover = this.popover = new StyledElements.Popover({
                 placement: ['top', 'bottom', 'right', 'left'],
                 title: feature.get('title'),
                 content: new StyledElements.Fragment(feature.get('content')),

--- a/tests/helpers/ol.js
+++ b/tests/helpers/ol.js
@@ -23,7 +23,7 @@
             Style: function () {}
         },
         Map: jasmine.createSpy('Map').and.callFake(function () {
-            var layers = {
+            const layers = {
                 _layers: [],
                 insertAt: jasmine.createSpy('insertAt').and.callFake(function (index, layer) {
                     this._layers.splice(index, 0, layer);

--- a/tests/js/OpenlayersWidgetSpec.js
+++ b/tests/js/OpenlayersWidgetSpec.js
@@ -3,7 +3,7 @@
  *   Copyright (c) 2017-2021 Future Internet Consulting and Development Solutions S.L.
  */
 
-/* global MashupPlatform, MockMP, ol, Widget */
+/* global MashupPlatform, MockMP, ol, StyledElements, Widget */
 
 (function () {
 
@@ -14,9 +14,9 @@
         '<div id="setcenter-button" class="se-btn"/><div id="setzoom-button" class="se-btn"/><div id="setcenterzoom-button" class="se-btn"/>';
 
     const clearDocument = function clearDocument() {
-        var elements = document.querySelectorAll('body > *:not(.jasmine_html-reporter)');
+        const elements = document.querySelectorAll('body > *:not(.jasmine_html-reporter)');
 
-        for (var i = 0; i < elements.length; i++) {
+        for (let i = 0; i < elements.length; i++) {
             elements[i].remove();
         }
     };
@@ -24,11 +24,11 @@
     const deepFreeze = function deepFreeze(obj) {
 
         // Retrieve the property names defined on obj
-        var propNames = Object.getOwnPropertyNames(obj);
+        const propNames = Object.getOwnPropertyNames(obj);
 
         // Freeze properties before freezing self
-        propNames.forEach(function(name) {
-            var prop = obj[name];
+        propNames.forEach(function (name) {
+            const prop = obj[name];
 
             // Freeze prop if it is an object
             if (typeof prop == 'object' && prop !== null) {
@@ -53,7 +53,7 @@
 
     describe("ol3-map", () => {
 
-        var widget;
+        let widget;
 
         beforeAll(() => {
             window.MashupPlatform = new MockMP({
@@ -148,7 +148,7 @@
 
                     widget.init();
 
-                    let layers_button = document.getElementById('button');
+                    const layers_button = document.getElementById('button');
                     expect(layers_button.className).toBe('se-btn fade');
                 });
 
@@ -157,29 +157,29 @@
 
                     widget.init();
 
-                    let layers_button = document.getElementById('button');
+                    const layers_button = document.getElementById('button');
                     expect(layers_button.className).toBe('se-btn fade in');
                 });
 
                 it("widget ref (click)", () => {
-                    let ref = "CoNWeT/layer-selector/0.4";
+                    const ref = "CoNWeT/layer-selector/0.4";
                     MashupPlatform.prefs.set("layerswidget", ref);
                     widget.init();
                     createAddWidgetMock();
 
-                    let layers_button = document.getElementById('button');
+                    const layers_button = document.getElementById('button');
                     layers_button.click();
                     expect(MashupPlatform.mashup.addWidget).toHaveBeenCalledWith(ref, jasmine.any(Object));
                     expect(MashupPlatform.mashup.addWidget().outputs.layerInfoOutput.connect).toHaveBeenCalledWith(MashupPlatform.widget.inputs.layerInfo);
                 });
 
                 it("widget ref (creation is cached)", () => {
-                    let ref = "CoNWeT/layer-selector/0.4";
+                    const ref = "CoNWeT/layer-selector/0.4";
                     MashupPlatform.prefs.set("layerswidget", ref);
                     widget.init();
                     createAddWidgetMock();
 
-                    let layers_button = document.getElementById('button');
+                    const layers_button = document.getElementById('button');
                     layers_button.click();
                     MashupPlatform.mashup.addWidget.calls.reset();
                     layers_button.click();
@@ -187,25 +187,25 @@
                 });
 
                 it("widget ref (listens close events)", () => {
-                    let ref = "CoNWeT/layer-selector/0.4";
+                    const ref = "CoNWeT/layer-selector/0.4";
                     MashupPlatform.prefs.set("layerswidget", ref);
                     widget.init();
                     createAddWidgetMock();
 
-                    let layers_button = document.getElementById('button');
+                    const layers_button = document.getElementById('button');
                     layers_button.click();
                     expect(MashupPlatform.mashup.addWidget().addEventListener).toHaveBeenCalledWith("remove", jasmine.any(Function));
                     MashupPlatform.mashup.addWidget().addEventListener.calls.argsFor(0)[1]();
                 });
 
                 it("widget ref (creation after close)", () => {
-                    let ref = "CoNWeT/layer-selector/0.4";
+                    const ref = "CoNWeT/layer-selector/0.4";
                     MashupPlatform.prefs.set("layerswidget", ref);
                     widget.init();
                     createAddWidgetMock();
 
                     // Open layers widget
-                    let layers_button = document.getElementById('button');
+                    const layers_button = document.getElementById('button');
                     layers_button.click();
                     // Close it
                     MashupPlatform.mashup.addWidget().addEventListener.calls.argsFor(0)[1]();
@@ -330,8 +330,8 @@
             describe("click", () => {
 
                 it("on a not selected feature", () => {
-                    let pixel_mock = jasmine.createSpy('pixel');
-                    let feature_mock = new ol.Feature();
+                    const pixel_mock = jasmine.createSpy('pixel');
+                    const feature_mock = new ol.Feature();
                     feature_mock.set('selectable', true);
                     widget.init();
                     spyOn(widget, "select_feature");
@@ -349,12 +349,12 @@
                 });
 
                 it("on a not selected feature (through selection menu)", () => {
-                    let pixel_mock = jasmine.createSpy('pixel');
-                    let feature1_mock = new ol.Feature();
+                    const pixel_mock = jasmine.createSpy('pixel');
+                    const feature1_mock = new ol.Feature();
                     feature1_mock.set('selectable', true);
-                    let feature2_mock = new ol.Feature();
+                    const feature2_mock = new ol.Feature();
                     feature2_mock.set('selectable', true);
-                    let feature3_mock = new ol.Feature();
+                    const feature3_mock = new ol.Feature();
                     feature3_mock.set('selectable', true);
                     widget.init();
                     spyOn(widget, "select_feature");
@@ -378,13 +378,13 @@
 
                 it("on a not selected feature (through selection menu of a cluster)", () => {
                     MashupPlatform.prefs.set("useclustering", true);
-                    let pixel_mock = jasmine.createSpy('pixel');
-                    let feature1_mock = new ol.Feature();
+                    const pixel_mock = jasmine.createSpy('pixel');
+                    const feature1_mock = new ol.Feature();
                     feature1_mock.set('selectable', true);
-                    let feature2_mock = new ol.Feature();
-                    let feature3_mock = new ol.Feature();
+                    const feature2_mock = new ol.Feature();
+                    const feature3_mock = new ol.Feature();
                     feature3_mock.set('selectable', true);
-                    let cluster_feature_mock = new ol.Feature();
+                    const cluster_feature_mock = new ol.Feature();
                     spyOn(cluster_feature_mock, "get").and.returnValue([feature1_mock, feature2_mock, feature3_mock]);
                     widget.init();
                     spyOn(widget, "select_feature");
@@ -407,8 +407,8 @@
                 });
 
                 it("on a not selectable feature", () => {
-                    let pixel_mock = jasmine.createSpy('pixel');
-                    let feature_mock = new ol.Feature();
+                    const pixel_mock = jasmine.createSpy('pixel');
+                    const feature_mock = new ol.Feature();
                     feature_mock.set('selectable', false);
                     widget.init();
                     spyOn(widget, "select_feature");
@@ -426,13 +426,13 @@
                 });
 
                 it("on a not selected feature (with a marker)", (done) => {
-                    let pixel_mock = jasmine.createSpy('pixel');
-                    let feature_mock = new ol.Feature();
+                    const pixel_mock = jasmine.createSpy('pixel');
+                    const feature_mock = new ol.Feature();
                     feature_mock.set('selectable', true);
                     feature_mock.set("content", "mycontent");
                     feature_mock.set("data", {});
                     feature_mock.setGeometry(new ol.geom.Point([0, 0]));
-                    let style_mock = new ol.style.Style();
+                    const style_mock = new ol.style.Style();
                     spyOn(feature_mock, "getStyle").and.callFake(() => {return () => {return style_mock};});
                     spyOn(style_mock, 'getImage').and.returnValue({
                         getScale: () => {return 0.5;},
@@ -461,8 +461,8 @@
                 });
 
                 it("on the selected feature", () => {
-                    let pixel_mock = jasmine.createSpy('pixel');
-                    let feature_mock = new ol.Feature();
+                    const pixel_mock = jasmine.createSpy('pixel');
+                    const feature_mock = new ol.Feature();
                     feature_mock.set("data", {});
                     feature_mock.set('selectable', true);
                     widget.init();
@@ -482,13 +482,13 @@
                 });
 
                 it("on the selected feature (through selection menu)", () => {
-                    let pixel_mock = jasmine.createSpy('pixel');
-                    let feature1_mock = new ol.Feature();
+                    const pixel_mock = jasmine.createSpy('pixel');
+                    const feature1_mock = new ol.Feature();
                     feature1_mock.set('selectable', true);
-                    let feature2_mock = new ol.Feature();
+                    const feature2_mock = new ol.Feature();
                     feature2_mock.set('selectable', true);
                     feature2_mock.set('data', {});
-                    let feature3_mock = new ol.Feature();
+                    const feature3_mock = new ol.Feature();
                     feature3_mock.set('selectable', true);
                     widget.init();
                     widget.selected_feature = feature2_mock;
@@ -509,10 +509,10 @@
                 });
 
                 it("on a not selected feature (but while there is a selected feature)", () => {
-                    let pixel_mock = jasmine.createSpy('pixel');
-                    let feature_mock1 = new ol.Feature();
+                    const pixel_mock = jasmine.createSpy('pixel');
+                    const feature_mock1 = new ol.Feature();
                     feature_mock1.set('selectable', true);
-                    let feature_mock2 = new ol.Feature();
+                    const feature_mock2 = new ol.Feature();
                     feature_mock2.set('selectable', true);
                     widget.init();
                     widget.selected_feature = feature_mock1;
@@ -536,7 +536,7 @@
                 });
 
                 it("outside any feature", () => {
-                    let pixel_mock = jasmine.createSpy('pixel');
+                    const pixel_mock = jasmine.createSpy('pixel');
                     widget.init();
                     spyOn(widget, "select_feature");
                     spyOn(widget.map, 'forEachFeatureAtPixel').and.callFake((pixel, listener) => {
@@ -554,8 +554,8 @@
                 });
 
                 it("outside any feature (but while there is a selected feature)", (done) => {
-                    let pixel_mock = jasmine.createSpy('pixel');
-                    let feature_mock = new ol.Feature();
+                    const pixel_mock = jasmine.createSpy('pixel');
+                    const feature_mock = new ol.Feature();
                     feature_mock.set('selectable', true);
                     feature_mock.set("content", "my content");
                     feature_mock.set("data", {});
@@ -595,8 +595,7 @@
                 });
 
                 it("outside the widget (but while there is a selected feature)", () => {
-                    let pixel_mock = jasmine.createSpy('pixel');
-                    let feature_mock = new ol.Feature();
+                    const feature_mock = new ol.Feature();
                     feature_mock.set('selectable', true);
                     feature_mock.setGeometry(new ol.geom.Point([0, 0]));
                     feature_mock.setStyle(() => {return new ol.style.Style()});
@@ -606,7 +605,7 @@
                     widget.init();
                     widget.select_feature(feature_mock);
                     MashupPlatform.widget.outputs.poiOutput.reset();
-                    let popover = widget.popover;
+                    const popover = widget.popover;
                     spyOn(popover, "on");
                     spyOn(widget, "select_feature");
 
@@ -838,7 +837,7 @@
                 }));
                 expect(widget.vector_source.addFeature).toHaveBeenCalledTimes(1);
                 expect(widget.vector_source.addFeature).toHaveBeenCalledWith(jasmine.any(ol.Feature));
-                let feature = widget.vector_source.addFeature.calls.argsFor(0)[0];
+                const feature = widget.vector_source.addFeature.calls.argsFor(0)[0];
                 // Widget should add a marker point
                 expect(feature.getGeometry().getType()).toBe("GeometryCollection");
             });
@@ -857,7 +856,7 @@
                 }));
                 expect(widget.vector_source.addFeature).toHaveBeenCalledTimes(1);
                 expect(widget.vector_source.addFeature).toHaveBeenCalledWith(jasmine.any(ol.Feature));
-                let feature = widget.vector_source.addFeature.calls.argsFor(0)[0];
+                const feature = widget.vector_source.addFeature.calls.argsFor(0)[0];
                 // Widget should add a marker point
                 expect(feature.getGeometry().getType()).toBe("GeometryCollection");
             });
@@ -879,14 +878,14 @@
 
             it("supports updating PoIs", () => {
                 widget.init();
-                var feature_mock = new ol.Feature();
+                const feature_mock = new ol.Feature();
                 spyOn(feature_mock, 'set');
                 spyOn(feature_mock, 'setProperties');
                 spyOn(feature_mock, 'setStyle');
 
                 spyOn(widget.vector_source, 'addFeature');
                 spyOn(widget.vector_source, 'getFeatureById').and.returnValue(feature_mock);
-                let poi_info = deepFreeze({
+                const poi_info = deepFreeze({
                     id: '1',
                     data: {},
                     location: {
@@ -914,14 +913,14 @@
 
             it("supports updating selected PoIs", () => {
                 widget.init();
-                var feature_mock = new ol.Feature();
+                const feature_mock = new ol.Feature();
                 spyOn(feature_mock, 'set');
                 spyOn(feature_mock, 'setProperties');
                 spyOn(feature_mock, 'setStyle');
 
                 spyOn(widget.vector_source, 'addFeature');
                 spyOn(widget.vector_source, 'getFeatureById').and.returnValue(feature_mock);
-                let poi_info = deepFreeze({
+                const poi_info = deepFreeze({
                     id: '1',
                     data: {},
                     location: {
@@ -944,16 +943,16 @@
                 widget.registerPoI(poi_info);
 
                 expect(feature_mock.setStyle).toHaveBeenCalledTimes(3);
-                let style1 = feature_mock.setStyle.calls.argsFor(0)[0];
-                let style2 = feature_mock.setStyle.calls.argsFor(1)[0];
-                let style3 = feature_mock.setStyle.calls.argsFor(2)[0];
+                const style1 = feature_mock.setStyle.calls.argsFor(0)[0];
+                const style2 = feature_mock.setStyle.calls.argsFor(1)[0];
+                const style3 = feature_mock.setStyle.calls.argsFor(2)[0];
 
                 expect(style1).not.toBe(style2);
                 expect(style1).toBe(style3);
             });
 
             it("sends update events when updating the selected PoI", () => {
-                var feature_mock = new ol.Feature();
+                const feature_mock = new ol.Feature();
                 widget.init();
                 widget.selected_feature = feature_mock;
                 spyOn(feature_mock, 'set');
@@ -961,7 +960,7 @@
                 spyOn(feature_mock, 'setStyle');
                 spyOn(widget.vector_source, 'addFeature');
                 spyOn(widget.vector_source, 'getFeatureById').and.returnValue(feature_mock);
-                let poi_info = deepFreeze({
+                const poi_info = deepFreeze({
                     id: '1',
                     data: {},
                     location: {
@@ -993,8 +992,8 @@
                         }));
                         expect(widget.vector_source.addFeature).toHaveBeenCalledTimes(1);
                         expect(widget.vector_source.addFeature).toHaveBeenCalledWith(jasmine.any(ol.Feature));
-                        let feature = widget.vector_source.addFeature.calls.argsFor(0)[0];
-                        let fstyle = feature.getStyle()(feature);
+                        const feature = widget.vector_source.addFeature.calls.argsFor(0)[0];
+                        const fstyle = feature.getStyle()(feature);
                         expect(fstyle.getStroke().getColor()).toEqual(expected.stroke.color);
                         expect(fstyle.getStroke().getWidth()).toEqual(expected.stroke.width);
                         expect(fstyle.getFill().getColor()).toEqual(expected.fill.color);
@@ -1040,8 +1039,8 @@
                         }));
                         expect(widget.vector_source.addFeature).toHaveBeenCalledTimes(1);
                         expect(widget.vector_source.addFeature).toHaveBeenCalledWith(jasmine.any(ol.Feature));
-                        let feature = widget.vector_source.addFeature.calls.argsFor(0)[0];
-                        let fimage = feature.getStyle()(feature).getImage();
+                        const feature = widget.vector_source.addFeature.calls.argsFor(0)[0];
+                        const fimage = feature.getStyle()(feature).getImage();
                         // TODO anchor can only be tested if anchorXUnits and anchorYUnits are both set to pixels
                         if (expected.anchor != null) {
                             expect(fimage.getAnchor()).toEqual(expected.anchor);
@@ -1076,7 +1075,6 @@
 
                 it("Should support caching styles", () => {
                     const hash = "vendor:domain:id";
-                    const expected = {opacity: 0.75, src: "http://localhost:9876/images/icon.png", scale: 1};
                     const iconStyle = {
                         anchor: [40, 50],
                         anchorXUnits: 'pixels',
@@ -1108,8 +1106,8 @@
                         },
                         icon: iconStyle,
                     }));
-                    let feature1 = widget.vector_source.addFeature.calls.argsFor(0)[0];
-                    let feature2 = widget.vector_source.addFeature.calls.argsFor(1)[0];
+                    const feature1 = widget.vector_source.addFeature.calls.argsFor(0)[0];
+                    const feature2 = widget.vector_source.addFeature.calls.argsFor(1)[0];
                     expect(feature1.getStyle()).toBe(feature2.getStyle());
                 });
 
@@ -1131,8 +1129,8 @@
                         }));
                         expect(widget.vector_source.addFeature).toHaveBeenCalledTimes(1);
                         expect(widget.vector_source.addFeature).toHaveBeenCalledWith(jasmine.any(ol.Feature));
-                        let feature = widget.vector_source.addFeature.calls.argsFor(0)[0];
-                        let fstyle = feature.getStyle()(feature, resolution);
+                        const feature = widget.vector_source.addFeature.calls.argsFor(0)[0];
+                        const fstyle = feature.getStyle()(feature, resolution);
                         expect(fstyle).toEqual(displayed ? jasmine.any(ol.style.Style) : null);
                     };
                 };
@@ -1158,8 +1156,8 @@
                         }));
                         expect(widget.vector_source.addFeature).toHaveBeenCalledTimes(1);
                         expect(widget.vector_source.addFeature).toHaveBeenCalledWith(jasmine.any(ol.Feature));
-                        let feature = widget.vector_source.addFeature.calls.argsFor(0)[0];
-                        let fstyle = feature.getStyle()(feature, resolution);
+                        const feature = widget.vector_source.addFeature.calls.argsFor(0)[0];
+                        const fstyle = feature.getStyle()(feature, resolution);
                         expect(fstyle).toEqual(displayed ? jasmine.any(ol.style.Style) : null);
                     };
                 };
@@ -1185,7 +1183,7 @@
             });
 
             it("should maintain current selection if it exists on the new status", () => {
-                let poi_info = deepFreeze({
+                const poi_info = deepFreeze({
                     id: '1',
                     data: {},
                     location: {
@@ -1194,13 +1192,13 @@
                     }
                 });
                 widget.init();
-                let initial_feature_mock = new ol.Feature();
+                const initial_feature_mock = new ol.Feature();
                 initial_feature_mock.setId("1");
                 widget.selected_feature = initial_feature_mock;
                 widget.popover = {
                     hide: jasmine.createSpy('hide')
                 };
-                let new_feature_mock = new ol.Feature();
+                const new_feature_mock = new ol.Feature();
                 spyOn(new_feature_mock, "get").and.returnValue(poi_info);
                 spyOn(widget, "registerPoI");
                 spyOn(widget, "select_feature");
@@ -1216,7 +1214,7 @@
             });
 
             it("should clean current selection if it does not exist on the new status", () => {
-                let poi_info = deepFreeze({
+                const poi_info = deepFreeze({
                     id: '1',
                     data: {},
                     location: {
@@ -1225,10 +1223,10 @@
                     }
                 });
                 widget.init();
-                let initial_feature_mock = new ol.Feature();
+                const initial_feature_mock = new ol.Feature();
                 initial_feature_mock.setId("5");
                 widget.selected_feature = initial_feature_mock;
-                let popover = widget.popover = {
+                const popover = widget.popover = {
                     hide: jasmine.createSpy('hide')
                 };
                 spyOn(widget, 'registerPoI');
@@ -1263,7 +1261,7 @@
                 spyOn(widget.map.getView(), 'getZoom').and.returnValue(11);
                 spyOn(ol.extent, 'containsExtent').and.returnValue(true);
                 // TODO
-                let poi_info = deepFreeze({
+                const poi_info = deepFreeze({
                     id: '1',
                     data: {
                         iconHighlighted: {
@@ -1278,7 +1276,7 @@
                     }
                 });
                 widget.registerPoI(poi_info);
-                let feature = widget.vector_source.addFeature.calls.argsFor(0)[0];
+                const feature = widget.vector_source.addFeature.calls.argsFor(0)[0];
                 spyOn(feature, "setStyle");
 
                 widget.centerPoI([{id: '1'}]);
@@ -1293,7 +1291,7 @@
                 widget.init();
                 spyOn(widget.map.getView(), 'fit').and.callThrough();
                 // TODO
-                let poi_info = deepFreeze({
+                const poi_info = deepFreeze({
                     id: '1',
                     data: {
                         iconHighlighted: {
@@ -1323,7 +1321,7 @@
             it("should manage selection changes", (done) => {
                 widget.init();
                 spyOn(widget.map.getView(), 'fit').and.callThrough();
-                let poi_info1 = deepFreeze({
+                const poi_info1 = deepFreeze({
                     id: '1',
                     infoWindow: "Hello world!",
                     location: {
@@ -1333,7 +1331,7 @@
                 });
                 widget.registerPoI(poi_info1);
                 spyOn(widget.vector_source, 'addFeature').and.callThrough();
-                let poi_info2 = deepFreeze({
+                const poi_info2 = deepFreeze({
                     id: '2',
                     data: {
                         iconHighlighted: {
@@ -1348,7 +1346,7 @@
                     }
                 });
                 widget.registerPoI(poi_info2);
-                let feature = widget.vector_source.addFeature.calls.argsFor(0)[0];
+                const feature = widget.vector_source.addFeature.calls.argsFor(0)[0];
                 spyOn(widget.map, 'getPixelFromCoordinate').and.returnValue([0, 0]);
                 widget.centerPoI([{id: '1'}]);
                 widget.map.getView().fit.calls.reset();
@@ -1441,8 +1439,8 @@
 
         describe("addLayer(options)", () => {
 
-            var mock_layers = function mock_layers(widget) {
-                var layers_mock = {
+            const mock_layers = function mock_layers(widget) {
+                const layers_mock = {
                     getLength: () => {return 2;},
                     insertAt: jasmine.createSpy('insertAt')
                 };
@@ -1467,7 +1465,7 @@
                 // viewMaxZoom
                 // visible
                 widget.init();
-                var layers_mock = mock_layers(widget);
+                const layers_mock = mock_layers(widget);
 
                 widget.addLayer({
                     type: "ImageStatic",
@@ -1495,7 +1493,7 @@
 
             it("transform extents from EPSG:4326 to current map projection by default", () => {
                 widget.init();
-                var layers_mock = mock_layers(widget);
+                const layers_mock = mock_layers(widget);
 
                 widget.addLayer({
                     type: "ImageStatic",
@@ -1517,7 +1515,7 @@
 
             it("supports Image WMS layers", () => {
                 widget.init();
-                var layers_mock = mock_layers(widget);
+                const layers_mock = mock_layers(widget);
 
                 widget.addLayer({
                     type: "ImageWMS",
@@ -1534,7 +1532,7 @@
 
             it("supports Image WMS layers (provides a default params option)", () => {
                 widget.init();
-                var layers_mock = mock_layers(widget);
+                const layers_mock = mock_layers(widget);
 
                 widget.addLayer({
                     type: "ImageWMS",
@@ -1548,7 +1546,7 @@
 
             it("supports Image WMS layers (uses layer id as default LAYERS parameter)", () => {
                 widget.init();
-                var layers_mock = mock_layers(widget);
+                const layers_mock = mock_layers(widget);
 
                 widget.addLayer({
                     type: "ImageWMS",
@@ -1565,7 +1563,7 @@
 
             it("supports ImageArcGISRest layers", () => {
                 widget.init();
-                var layers_mock = mock_layers(widget);
+                const layers_mock = mock_layers(widget);
 
                 widget.addLayer({
                     type: "ImageArcGISRest",
@@ -1579,7 +1577,7 @@
 
             it("supports ImageMapGuide layers", () => {
                 widget.init();
-                var layers_mock = mock_layers(widget);
+                const layers_mock = mock_layers(widget);
 
                 widget.addLayer({
                     type: "ImageMapGuide",
@@ -1593,7 +1591,7 @@
 
             it("supports ImageStatic layers", () => {
                 widget.init();
-                var layers_mock = mock_layers(widget);
+                const layers_mock = mock_layers(widget);
 
                 widget.addLayer({
                     type: "ImageStatic",
@@ -1607,7 +1605,7 @@
 
             it("supports Vector layers", () => {
                 widget.init();
-                var layers_mock = mock_layers(widget);
+                const layers_mock = mock_layers(widget);
 
                 widget.addLayer({
                     type: "Vector",
@@ -1622,7 +1620,6 @@
 
             it("raises an EndpointValueError exception when trying to create a Vector layer without providing the format", () => {
                 widget.init();
-                var layers_mock = mock_layers(widget);
 
                 expect(() => {
                     widget.addLayer({
@@ -1635,7 +1632,6 @@
 
             it("raises an EndpointValueError exception when trying to create a Vector layer without providing a layer url", () => {
                 widget.init();
-                var layers_mock = mock_layers(widget);
 
                 expect(() => {
                     widget.addLayer({
@@ -1648,7 +1644,7 @@
 
             it("supports Vector layers (with format options)", () => {
                 widget.init();
-                var layers_mock = mock_layers(widget);
+                const layers_mock = mock_layers(widget);
 
                 widget.addLayer({
                     type: "Vector",
@@ -1666,7 +1662,7 @@
 
             it("supports Vector layers (with GML format options)", () => {
                 widget.init();
-                var layers_mock = mock_layers(widget);
+                const layers_mock = mock_layers(widget);
 
                 widget.addLayer({
                     type: "Vector",
@@ -1685,7 +1681,7 @@
 
             it("supports VectorTile layers", () => {
                 widget.init();
-                var layers_mock = mock_layers(widget);
+                const layers_mock = mock_layers(widget);
 
                 widget.addLayer({
                     type: "VectorTile",
@@ -1704,7 +1700,7 @@
 
             it("supports OSM layers", () => {
                 widget.init();
-                var layers_mock = mock_layers(widget);
+                const layers_mock = mock_layers(widget);
 
                 widget.addLayer({
                     type: "OSM",
@@ -1717,7 +1713,7 @@
 
             it("supports Tile WMS layers", () => {
                 widget.init();
-                var layers_mock = mock_layers(widget);
+                const layers_mock = mock_layers(widget);
 
                 widget.addLayer({
                     type: "TileWMS",
@@ -1736,7 +1732,7 @@
 
             it("supports Tile WMS layers (provides a default params option)", () => {
                 widget.init();
-                var layers_mock = mock_layers(widget);
+                const layers_mock = mock_layers(widget);
 
                 widget.addLayer({
                     type: "TileWMS",
@@ -1751,7 +1747,7 @@
 
             it("supports Tile WMS layers (uses layer id as default LAYERS parameter)", () => {
                 widget.init();
-                var layers_mock = mock_layers(widget);
+                const layers_mock = mock_layers(widget);
 
                 widget.addLayer({
                     type: "TileWMS",
@@ -1769,7 +1765,7 @@
 
             it("supports Tile JSON layers", () => {
                 widget.init();
-                var layers_mock = mock_layers(widget);
+                const layers_mock = mock_layers(widget);
 
                 widget.addLayer({
                     type: "TileJSON",
@@ -1784,7 +1780,7 @@
 
             it("supports Tile UTF Grid layers", () => {
                 widget.init();
-                var layers_mock = mock_layers(widget);
+                const layers_mock = mock_layers(widget);
 
                 widget.addLayer({
                     type: "TileUTFGrid",
@@ -1798,7 +1794,7 @@
 
             it("supports XYZ layers", () => {
                 widget.init();
-                var layers_mock = mock_layers(widget);
+                const layers_mock = mock_layers(widget);
 
                 widget.addLayer({
                     type: "XYZ",
@@ -1812,7 +1808,7 @@
 
             it("supports Stamen layers", () => {
                 widget.init();
-                var layers_mock = mock_layers(widget);
+                const layers_mock = mock_layers(widget);
 
                 widget.addLayer({
                     type: "Stamen",
@@ -1826,7 +1822,7 @@
 
             it("supports BingMaps layers", () => {
                 widget.init();
-                var layers_mock = mock_layers(widget);
+                const layers_mock = mock_layers(widget);
 
                 widget.addLayer({
                     type: "BingMaps",
@@ -1840,7 +1836,7 @@
 
             it("supports CartoDB layers", () => {
                 widget.init();
-                var layers_mock = mock_layers(widget);
+                const layers_mock = mock_layers(widget);
 
                 widget.addLayer({
                     type: "CartoDB",
@@ -1864,7 +1860,7 @@
 
             it("supports WMTS layers", () => {
                 widget.init();
-                var layers_mock = mock_layers(widget);
+                const layers_mock = mock_layers(widget);
 
                 widget.addLayer({
                     type: "WMTS",
@@ -1878,7 +1874,7 @@
 
             it("supports Zoomify layers", () => {
                 widget.init();
-                var layers_mock = mock_layers(widget);
+                const layers_mock = mock_layers(widget);
 
                 widget.addLayer({
                     type: "Zoomify",
@@ -1893,10 +1889,10 @@
 
             it("replaces layers with the same id", () => {
                 widget.init();
-                var layers_mock = mock_layers(widget);
+                const layers_mock = mock_layers(widget);
                 spyOn(widget.map, 'removeLayer');
-                let layer_mock = jasmine.createSpy('layer_mock');
-                widget.layers["LayerName"] = layer_mock;
+                const layer_mock = jasmine.createSpy('layer_mock');
+                widget.layers.LayerName = layer_mock;
 
                 widget.addLayer({
                     type: "Vector",
@@ -1932,8 +1928,8 @@
             it("removes existing layers", () => {
                 widget.init();
                 spyOn(widget.map, 'removeLayer');
-                let layer_mock = jasmine.createSpy('layer_mock');
-                widget.layers["LayerName"] = layer_mock;
+                const layer_mock = jasmine.createSpy('layer_mock');
+                widget.layers.LayerName = layer_mock;
 
                 widget.removeLayer({
                     id: "LayerName"
@@ -1964,9 +1960,8 @@
                     setVisible: jasmine.createSpy("setVisible"),
                     _layer_type: "BingMaps"
                 };
-                widget.layers["LayerName"] = layer_mock;
+                widget.layers.LayerName = layer_mock;
 
-                const newurl = "https://newserver.example.com";
                 widget.updateLayer({
                     id: "LayerName",
                     visible: true,
@@ -1986,7 +1981,7 @@
                     getSource: jasmine.createSpy("getSource").and.returnValue(source_mock),
                     _layer_type: "XYZ"
                 };
-                widget.layers["LayerName"] = layer_mock;
+                widget.layers.LayerName = layer_mock;
 
                 const newurl = "https://newserver.example.com";
                 widget.updateLayer({
@@ -2004,7 +1999,7 @@
                     getSource: jasmine.createSpy("getSource").and.returnValue(source_mock),
                     _layer_type: "XYZ"
                 };
-                widget.layers["LayerName"] = layer_mock;
+                widget.layers.LayerName = layer_mock;
 
                 widget.updateLayer({
                     id: "LayerName"
@@ -2028,7 +2023,7 @@
             it("switches current base layer", () => {
                 widget.init();
 
-                let initial_base_layer = widget.base_layer;
+                const initial_base_layer = widget.base_layer;
                 widget.setBaseLayer({
                     id: 'CARTODB_LIGHT'
                 });
@@ -2044,8 +2039,8 @@
                 widget.init();
                 spyOn(widget.vector_source, 'addFeature');
                 spyOn(widget, 'get_styleSheets').and.returnValue([
-                  {cssRules: [{selectorText: '.fa-star::before', style: {content: '\uf005'}}]},
-                  {cssRules: [{selectorText: '', style: {content: ''}}]}
+                    {cssRules: [{selectorText: '.fa-star::before', style: {content: '\uf005'}}]},
+                    {cssRules: [{selectorText: '', style: {content: ''}}]}
                 ]);
                 widget.registerPoI(deepFreeze({
                     id: '1',
@@ -2066,7 +2061,7 @@
                 widget.init();
                 spyOn(widget.vector_source, 'addFeature');
                 spyOn(widget, 'get_styleSheets').and.returnValue([
-                  {cssRules: [{selectorText: '.fa-star::before', style: {content: '\uf005'}}]}
+                    {cssRules: [{selectorText: '.fa-star::before', style: {content: '\uf005'}}]}
                 ]);
                 widget.registerPoI(deepFreeze({
                     id: '1',
@@ -2090,7 +2085,7 @@
                 widget.init();
                 spyOn(widget.vector_source, 'addFeature');
                 spyOn(widget, 'get_styleSheets').and.returnValue([
-                  {cssRules: [{selectorText: '.fa-star::before', style: {content: '\uf005'}}]}
+                    {cssRules: [{selectorText: '.fa-star::before', style: {content: '\uf005'}}]}
                 ]);
                 widget.registerPoI(deepFreeze({
                     id: '1',
@@ -2115,7 +2110,7 @@
                 widget.init();
                 spyOn(widget.vector_source, 'addFeature');
                 spyOn(widget, 'get_styleSheets').and.returnValue([
-                  {cssRules: [{selectorText: '.fa-star::before', style: {content: '\uf005'}}]}
+                    {cssRules: [{selectorText: '.fa-star::before', style: {content: '\uf005'}}]}
                 ]);
                 widget.registerPoI(deepFreeze({
                     id: '1',
@@ -2139,7 +2134,7 @@
                 widget.init();
                 spyOn(widget.vector_source, 'addFeature');
                 spyOn(widget, 'get_styleSheets').and.returnValue([
-                  {cssRules: [{selectorText: '.fa-star::before', style: {content: '\uf005'}}]}
+                    {cssRules: [{selectorText: '.fa-star::before', style: {content: '\uf005'}}]}
                 ]);
                 widget.registerPoI(deepFreeze({
                     id: '1',
@@ -2163,7 +2158,7 @@
                 widget.init();
                 spyOn(widget.vector_source, 'addFeature');
                 spyOn(widget, 'get_styleSheets').and.returnValue([
-                  {cssRules: [{selectorText: '.fa-star::before', style: {content: '\uf005'}}]}
+                    {cssRules: [{selectorText: '.fa-star::before', style: {content: '\uf005'}}]}
                 ]);
                 widget.registerPoI(deepFreeze({
                     id: '1',


### PR DESCRIPTION
This PR updates eslint configuration to forbid using `var` and require to use `let` and `const` instead.